### PR TITLE
278 absolute paths in compilation

### DIFF
--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -363,7 +363,7 @@ def compile_file(analysed_file, flags, output_fpath, mp_common_args):
     command.append(str(analysed_file.fpath))
     command.extend(['-o', str(output_fpath)])
 
-    run_command(command, cwd=analysed_file.fpath.parent)
+    run_command(command)
 
 
 # todo: move this

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -360,7 +360,7 @@ def compile_file(analysed_file, flags, output_fpath, mp_common_args):
         command.extend([known_compiler.module_folder_flag, str(mp_common_args.config.build_output)])
 
     # files
-    command.append(analysed_file.fpath.name)
+    command.append(str(analysed_file.fpath))
     command.extend(['-o', str(output_fpath)])
 
     run_command(command, cwd=analysed_file.fpath.parent)


### PR DESCRIPTION
This PR uses full paths for the source file name instead of a 'chdir' into the source directory and the compiling locally.

The advantage is that this way the compile line shown in the log files can be copy&pasted anywhere and will do the right thing - additionally, it is now the same as C compilation, so more consistent.