### PR TITLE
Create artefact store

### DIFF
--- a/tests/system_tests/CFortranInterop/test_CFortranInterop.py
+++ b/tests/system_tests/CFortranInterop/test_CFortranInterop.py
@@ -46,10 +46,10 @@ def test_CFortranInterop(tmp_path):
         #     '/lib/x86_64-linux-gnu/libgfortran.so.5',
         # ]
 
-    assert len(config._artefact_store[EXECUTABLES]) == 1
+    assert len(config.artefact_store[EXECUTABLES]) == 1
 
     # run
-    command = [str(config._artefact_store[EXECUTABLES][0])]
+    command = [str(config.artefact_store[EXECUTABLES][0])]
     res = subprocess.run(command, capture_output=True)
     output = res.stdout.decode()
     assert output == ''.join(open(PROJECT_SOURCE / 'expected.exec.txt').readlines())

--- a/tests/system_tests/CUserHeader/test_CUserHeader.py
+++ b/tests/system_tests/CUserHeader/test_CUserHeader.py
@@ -35,10 +35,10 @@ def test_CUseHeader(tmp_path):
 
         link_exe(config, linker='gcc', flags=['-lgfortran']),
 
-    assert len(config._artefact_store[EXECUTABLES]) == 1
+    assert len(config.artefact_store[EXECUTABLES]) == 1
 
     # run
-    command = [str(config._artefact_store[EXECUTABLES][0])]
+    command = [str(config.artefact_store[EXECUTABLES][0])]
     res = subprocess.run(command, capture_output=True)
     output = res.stdout.decode()
     assert output == ''.join(open(PROJECT_SOURCE / 'expected.exec.txt').readlines())

--- a/tests/system_tests/FortranDependencies/test_FortranDependencies.py
+++ b/tests/system_tests/FortranDependencies/test_FortranDependencies.py
@@ -33,11 +33,11 @@ def test_FortranDependencies(tmp_path):
         compile_fortran(config, common_flags=['-c']),
         link_exe(config, linker='gcc', flags=['-lgfortran']),
 
-    assert len(config._artefact_store[EXECUTABLES]) == 2
+    assert len(config.artefact_store[EXECUTABLES]) == 2
 
     # run both exes
     output = set()
-    for exe in config._artefact_store[EXECUTABLES]:
+    for exe in config.artefact_store[EXECUTABLES]:
         res = subprocess.run(str(exe), capture_output=True)
         output.add(res.stdout.decode())
 

--- a/tests/system_tests/FortranPreProcess/test_FortranPreProcess.py
+++ b/tests/system_tests/FortranPreProcess/test_FortranPreProcess.py
@@ -36,13 +36,13 @@ def test_FortranPreProcess(tmp_path):
     # stay
     stay_config = build(fab_workspace=tmp_path, fpp_flags=['-P', '-DSHOULD_I_STAY=yes'])
 
-    stay_exe = stay_config._artefact_store[EXECUTABLES][0]
+    stay_exe = stay_config.artefact_store[EXECUTABLES][0]
     stay_res = subprocess.run(str(stay_exe), capture_output=True)
     assert stay_res.stdout.decode().strip() == 'I should stay'
 
     # go
     go_config = build(fab_workspace=tmp_path, fpp_flags=['-P'])
 
-    go_exe = go_config._artefact_store[EXECUTABLES][0]
+    go_exe = go_config.artefact_store[EXECUTABLES][0]
     go_res = subprocess.run(str(go_exe), capture_output=True)
     assert go_res.stdout.decode().strip() == 'I should go now'

--- a/tests/system_tests/MinimalC/test_MinimalC.py
+++ b/tests/system_tests/MinimalC/test_MinimalC.py
@@ -34,10 +34,10 @@ def test_MinimalC(tmp_path):
 
         link_exe(config, linker='gcc'),
 
-    assert len(config._artefact_store[EXECUTABLES]) == 1
+    assert len(config.artefact_store[EXECUTABLES]) == 1
 
     # run
-    command = [str(config._artefact_store[EXECUTABLES][0])]
+    command = [str(config.artefact_store[EXECUTABLES][0])]
     res = subprocess.run(command, capture_output=True)
     output = res.stdout.decode()
     assert output == 'Hello world!'

--- a/tests/system_tests/MinimalFortran/test_MinimalFortran.py
+++ b/tests/system_tests/MinimalFortran/test_MinimalFortran.py
@@ -32,10 +32,10 @@ def test_MinimalFortran(tmp_path):
         compile_fortran(config, common_flags=['-c']),
         link_exe(config, linker='gcc', flags=['-lgfortran']),
 
-    assert len(config._artefact_store[EXECUTABLES]) == 1
+    assert len(config.artefact_store[EXECUTABLES]) == 1
 
     # run
-    command = [str(config._artefact_store[EXECUTABLES][0])]
+    command = [str(config.artefact_store[EXECUTABLES][0])]
     res = subprocess.run(command, capture_output=True)
     output = res.stdout.decode()
     assert output.strip() == 'Hello world!'

--- a/tests/system_tests/psyclone/test_psyclone_system_test.py
+++ b/tests/system_tests/psyclone/test_psyclone_system_test.py
@@ -173,7 +173,7 @@ class TestPsyclone(object):
         # So use a list instead:
         assert all(list(config.prebuild_folder.glob(f)) == [] for f in expect_prebuild_files)
         assert all(list(config.build_output.glob(f)) == [] for f in expect_build_files)
-        with config:
+        with config, pytest.warns(UserWarning, match="no transformation script specified"):
             self.steps(config)
         assert all(list(config.prebuild_folder.glob(f)) != [] for f in expect_prebuild_files)
         assert all(list(config.build_output.glob(f)) != [] for f in expect_build_files)

--- a/tests/unit_tests/steps/test_archive_objects.py
+++ b/tests/unit_tests/steps/test_archive_objects.py
@@ -29,7 +29,7 @@ class Test_archive_objects(object):
         mock_run_command.assert_has_calls(expected_calls)
 
         # ensure the correct artefacts were created
-        assert config._artefact_store[OBJECT_ARCHIVES] == {
+        assert config.artefact_store[OBJECT_ARCHIVES] == {
             target: [str(config.build_output / f'{target}.a')] for target in targets}
 
     def test_for_library(self):
@@ -48,5 +48,5 @@ class Test_archive_objects(object):
             'ar', 'cr', str(config.build_output / 'mylib.a'), 'util1.o', 'util2.o'])
 
         # ensure the correct artefacts were created
-        assert config._artefact_store[OBJECT_ARCHIVES] == {
+        assert config.artefact_store[OBJECT_ARCHIVES] == {
             None: [str(config.build_output / 'mylib.a')]}

--- a/tests/unit_tests/steps/test_compile_c.py
+++ b/tests/unit_tests/steps/test_compile_c.py
@@ -16,7 +16,7 @@ def content(tmp_path):
     config = BuildConfig('proj', multiprocessing=False, fab_workspace=tmp_path)
 
     analysed_file = AnalysedC(fpath=Path(f'{config.source_root}/foo.c'), file_hash=0)
-    config._artefact_store[BUILD_TREES] = {None: {analysed_file.fpath: analysed_file}}
+    config.artefact_store[BUILD_TREES] = {None: {analysed_file.fpath: analysed_file}}
     expect_hash = 9120682468
     return config, analysed_file, expect_hash
 
@@ -50,7 +50,7 @@ class Test_CompileC(object):
         values['send_metric'].assert_called_once()
 
         # ensure it created the correct artefact collection
-        assert config._artefact_store[OBJECT_FILES] == {
+        assert config.artefact_store[OBJECT_FILES] == {
             None: {config.prebuild_folder / f'foo.{expect_hash:x}.o', }
         }
 

--- a/tests/unit_tests/steps/test_root_inc_files.py
+++ b/tests/unit_tests/steps/test_root_inc_files.py
@@ -14,7 +14,7 @@ class TestRootIncFiles(object):
         inc_files = [Path('/foo/source/bar.inc')]
 
         config = BuildConfig('proj')
-        config._artefact_store['all_source'] = inc_files
+        config.artefact_store['all_source'] = inc_files
 
         with mock.patch('fab.steps.root_inc_files.shutil') as mock_shutil:
             with mock.patch('fab.steps.root_inc_files.Path.mkdir'), \
@@ -27,7 +27,7 @@ class TestRootIncFiles(object):
         # ensure it doesn't try to copy a file in the build output
         config = BuildConfig('proj')
         inc_files = [Path('/foo/source/bar.inc'), config.build_output / 'fab.inc']
-        config._artefact_store['all_source'] = inc_files
+        config.artefact_store['all_source'] = inc_files
 
         with mock.patch('fab.steps.root_inc_files.shutil') as mock_shutil:
             with mock.patch('fab.steps.root_inc_files.Path.mkdir'), \
@@ -41,7 +41,7 @@ class TestRootIncFiles(object):
         inc_files = [Path('/foo/source/bar.inc'), Path('/foo/sauce/bar.inc')]
 
         config = BuildConfig('proj')
-        config._artefact_store['all_source'] = inc_files
+        config.artefact_store['all_source'] = inc_files
 
         with pytest.raises(FileExistsError):
             with mock.patch('fab.steps.root_inc_files.shutil'):

--- a/tests/unit_tests/test_build_config.py
+++ b/tests/unit_tests/test_build_config.py
@@ -25,6 +25,6 @@ class TestBuildConfig(object):
     def test_add_cleanup(self):
         # ensure the cleanup step is added
         with BuildConfig('proj') as config:
-            assert CLEANUP_COUNT not in config._artefact_store
+            assert CLEANUP_COUNT not in config.artefact_store
             pass
-        assert CLEANUP_COUNT in config._artefact_store
+        assert CLEANUP_COUNT in config.artefact_store


### PR DESCRIPTION
Oops, I discovered a few lines I forgot to change :( So, another PR for the same thing, this just fixes a few tests. While technically not wrong, I think using the getter for the artefact_store is the right way. There are a few assignments to the artefact_store in the tests left over, I think that's ok (since they are tests), in general we would not want a user to be able to re-assign the artefact store of a config, so I did not implement a setter for that reason.