### PR TITLE
Allowing file-specific transformation scripts

### DIFF
--- a/docs/source/writing_config.rst
+++ b/docs/source/writing_config.rst
@@ -142,10 +142,11 @@ before you run the :func:`~fab.steps.analyse.analyse` step below.
 * For :func:`~fab.steps.psyclone.preprocess_x90`:
             You can pass in `common_flags` list as an argument.
 * For :func:`~fab.steps.psyclone.psyclone`:
-            You can pass in 
+            You can pass in:
+
             * kernel file roots to `kernel_roots`, 
             * a function to get transformation script to `transformation_script` 
-                (see examples in ``~fab.run_configs.lfric.gungho.py`` and ``~fab.run_configs.lfric.atm.py``),
+              (see examples in ``~fab.run_configs.lfric.gungho.py`` and ``~fab.run_configs.lfric.atm.py``),
             * command-line arguments to `cli_args`,
             * override for input files to `source_getter`, 
             * folders containing override files to `overrides_folder`.

--- a/docs/source/writing_config.rst
+++ b/docs/source/writing_config.rst
@@ -132,6 +132,52 @@ Preprocessed files are created in the `'build_output'` folder, inside the projec
 After the fortran_preprocessor step, there will be a collection called ``"preprocessed_fortran"``, in the artefact store.
 
 
+PSyclone
+========
+
+If you want to use PSyclone to do code transformation and pre-processing (see https://github.com/stfc/PSyclone),
+you must run :func:`~fab.steps.psyclone.preprocess_x90` and :func:`~fab.steps.psyclone.psyclone`,
+before you run the :func:`~fab.steps.analyse.analyse` step below.
+
+* For :func:`~fab.steps.psyclone.preprocess_x90`:
+            You can pass in `common_flags` list as an argument.
+* For :func:`~fab.steps.psyclone.psyclone`:
+            You can pass in kernel file roots to `kernel_roots`, a function to get transformation script to
+            `transformation_script` (see examples in :ref:`~fab.run_configs.lfric.gungho.py` and
+            :ref:`~fab.run_configs.lfric.atm.py`), command-line arguments to `cli_args`,
+            override for input files to `source_getter`, and folders containing override files to `overrides_folder`
+
+
+.. code-block::
+    :linenos:
+    :caption: build_it.py
+    :emphasize-lines: 8,18,19
+
+    #!/usr/bin/env python3
+    from logging import getLogger
+
+    from fab.build_config import BuildConfig
+    from fab.steps.find_source_files import find_source_files
+    from fab.steps.grab.folder import grab_folder
+    from fab.steps.preprocess import preprocess_fortran
+    from fab.steps.psyclone import psyclone, preprocess_x90
+
+    logger = getLogger('fab')
+
+    if __name__ == '__main__':
+
+        with BuildConfig(project_label='<project label') as state:
+            grab_folder(state, src='<path to source folder>')
+            find_source_files(state)
+            preprocess_fortran(state)
+            preprocess_x90(state)
+            psyclone(state)
+
+
+After the psyclone step, you can find `_psy.f90` files in the `'build_output'` folder. There will be a collection
+called ``"psyclone_output"`` in the artefact store.
+
+
 .. _Analyse Overview:
 
 Analyse
@@ -149,7 +195,7 @@ The Analyse step looks for source to analyse in several collections:
 .. code-block::
     :linenos:
     :caption: build_it.py
-    :emphasize-lines: 4,18
+    :emphasize-lines: 4,21
 
     #!/usr/bin/env python3
     from logging import getLogger
@@ -159,6 +205,7 @@ The Analyse step looks for source to analyse in several collections:
     from fab.steps.find_source_files import find_source_files
     from fab.steps.grab.folder import grab_folder
     from fab.steps.preprocess import preprocess_fortran
+    from fab.steps.psyclone import psyclone, preprocess_x90
 
     logger = getLogger('fab')
 
@@ -168,6 +215,8 @@ The Analyse step looks for source to analyse in several collections:
             grab_folder(state, src='<path to source folder>')
             find_source_files(state)
             preprocess_fortran(state)
+            preprocess_x90(state)
+            psyclone(state)
             analyse(state, root_symbol='<program>')
 
 
@@ -187,7 +236,7 @@ then creates the executable.
 .. code-block::
     :linenos:
     :caption: build_it.py
-    :emphasize-lines: 6,9,21,22
+    :emphasize-lines: 6,9,24,25
 
     #!/usr/bin/env python3
     from logging import getLogger
@@ -199,6 +248,7 @@ then creates the executable.
     from fab.steps.grab.folder import grab_folder
     from fab.steps.link import link_exe
     from fab.steps.preprocess import preprocess_fortran
+    from fab.steps.psyclone import psyclone, preprocess_x90
 
     logger = getLogger('fab')
 
@@ -208,6 +258,8 @@ then creates the executable.
             grab_folder(state, src='<path to source folder>')
             find_source_files(state)
             preprocess_fortran(state)
+            preprocess_x90(state)
+            psyclone(state)
             analyse(state, root_symbol='<program>')
             compile_fortran(state)
             link_exe(state)

--- a/docs/source/writing_config.rst
+++ b/docs/source/writing_config.rst
@@ -64,7 +64,7 @@ A grab step will copy files from a folder or remote repo into a folder called
 
     if __name__ == '__main__':
 
-        with BuildConfig(project_label='<project label') as state:
+        with BuildConfig(project_label='<project label>') as state:
             grab_folder(state, src='<path to source folder>')
             find_source_files(state)
 
@@ -122,7 +122,7 @@ The Fortran preprocessor will read the :ref:`FPP<env_vars>` environment variable
 
     if __name__ == '__main__':
 
-        with BuildConfig(project_label='<project label') as state:
+        with BuildConfig(project_label='<project label>') as state:
             grab_folder(state, src='<path to source folder>')
             find_source_files(state)
             preprocess_fortran(state)
@@ -143,8 +143,8 @@ before you run the :func:`~fab.steps.analyse.analyse` step below.
             You can pass in `common_flags` list as an argument.
 * For :func:`~fab.steps.psyclone.psyclone`:
             You can pass in kernel file roots to `kernel_roots`, a function to get transformation script to
-            `transformation_script` (see examples in :ref:`~fab.run_configs.lfric.gungho.py` and
-            :ref:`~fab.run_configs.lfric.atm.py`), command-line arguments to `cli_args`,
+            `transformation_script` (see examples in ``~fab.run_configs.lfric.gungho.py`` and
+            ``~fab.run_configs.lfric.atm.py``), command-line arguments to `cli_args`,
             override for input files to `source_getter`, and folders containing override files to `overrides_folder`
 
 
@@ -166,7 +166,7 @@ before you run the :func:`~fab.steps.analyse.analyse` step below.
 
     if __name__ == '__main__':
 
-        with BuildConfig(project_label='<project label') as state:
+        with BuildConfig(project_label='<project label>') as state:
             grab_folder(state, src='<path to source folder>')
             find_source_files(state)
             preprocess_fortran(state)
@@ -174,8 +174,8 @@ before you run the :func:`~fab.steps.analyse.analyse` step below.
             psyclone(state)
 
 
-After the psyclone step, you can find `_psy.f90` files in the `'build_output'` folder. There will be a collection
-called ``"psyclone_output"`` in the artefact store.
+After the psyclone step, two new source files will be created for each .x90 file in the `'build_output'` folder.
+These two output files will be added under ``"psyclone_output"`` collection to the artefact store.
 
 
 .. _Analyse Overview:
@@ -211,7 +211,7 @@ The Analyse step looks for source to analyse in several collections:
 
     if __name__ == '__main__':
 
-        with BuildConfig(project_label='<project label') as state:
+        with BuildConfig(project_label='<project label>') as state:
             grab_folder(state, src='<path to source folder>')
             find_source_files(state)
             preprocess_fortran(state)
@@ -254,7 +254,7 @@ then creates the executable.
 
     if __name__ == '__main__':
 
-        with BuildConfig(project_label='<project label') as state:
+        with BuildConfig(project_label='<project label>') as state:
             grab_folder(state, src='<path to source folder>')
             find_source_files(state)
             preprocess_fortran(state)

--- a/docs/source/writing_config.rst
+++ b/docs/source/writing_config.rst
@@ -142,10 +142,13 @@ before you run the :func:`~fab.steps.analyse.analyse` step below.
 * For :func:`~fab.steps.psyclone.preprocess_x90`:
             You can pass in `common_flags` list as an argument.
 * For :func:`~fab.steps.psyclone.psyclone`:
-            You can pass in kernel file roots to `kernel_roots`, a function to get transformation script to
-            `transformation_script` (see examples in ``~fab.run_configs.lfric.gungho.py`` and
-            ``~fab.run_configs.lfric.atm.py``), command-line arguments to `cli_args`,
-            override for input files to `source_getter`, and folders containing override files to `overrides_folder`
+            You can pass in 
+            * kernel file roots to `kernel_roots`, 
+            * a function to get transformation script to `transformation_script` 
+                (see examples in ``~fab.run_configs.lfric.gungho.py`` and ``~fab.run_configs.lfric.atm.py``),
+            * command-line arguments to `cli_args`,
+            * override for input files to `source_getter`, 
+            * folders containing override files to `overrides_folder`.
 
 
 .. code-block::

--- a/run_configs/lfric/atm.py
+++ b/run_configs/lfric/atm.py
@@ -166,16 +166,14 @@ def get_transformation_script(fpath, config):
     :rtype: Path
 
     '''
-    global_transformation_script = config.source_root / 'lfric' / 'lfric_atm' / 'optimisation' / \
-        'meto-spice' / 'global.py'
-    local_transformation_script = config.source_root / 'lfric' / 'lfric_atm' / 'optimisation' / \
-        'meto-spice' / (fpath.relative_to(config.source_root).with_suffix('.py'))
-    if local_transformation_script:
+    optimisation_path = config.source_root / 'lfric' / 'lfric_atm' / 'optimisation' / 'meto-spice'
+    local_transformation_script = optimisation_path / (fpath.relative_to(config.source_root).with_suffix('.py'))
+    if local_transformation_script.exists():
         return local_transformation_script
-    elif global_transformation_script:
+    global_transformation_script = optimisation_path / 'global.py'
+    if global_transformation_script.exists():
         return global_transformation_script
-    else:
-        return ""
+    return ""
 
 
 if __name__ == '__main__':

--- a/run_configs/lfric/atm.py
+++ b/run_configs/lfric/atm.py
@@ -16,8 +16,6 @@ from fab.steps.find_source_files import find_source_files, Exclude, Include
 
 from grab_lfric import lfric_source_config, gpl_utils_source_config
 from lfric_common import configurator, fparser_workaround_stop_concatenation
-from fnmatch import fnmatch
-from string import Template
 
 logger = logging.getLogger('fab')
 
@@ -163,35 +161,20 @@ def file_filtering(config):
     ]
 
 
-def get_transformation_script(fpath):
+def get_transformation_script(fpath, config):
     ''':returns: the transformation script to be used by PSyclone.
     :rtype: Path
 
     '''
-    params = {'relative': fpath.parent, 'source': lfric_source_config.source_root,
-              'output': lfric_source_config.build_output}
-    global_transformation_script = '$source/lfric/lfric_atm/optimisation/meto-spice/global.py'
-    local_transformation_script = None
-    if global_transformation_script:
-        if local_transformation_script:
-            # global defined, local defined
-            for key_match in local_transformation_script:
-                if fnmatch(str(fpath), Template(key_match).substitute(params)):
-                    # use templating to render any relative paths
-                    return Template(local_transformation_script[key_match]).substitute(params)
-            return Template(global_transformation_script).substitute(params)
-        else:
-            # global defined, local not defined
-            return Template(global_transformation_script).substitute(params)
-    elif local_transformation_script:
-        # global not defined, local defined
-        for key_match in local_transformation_script:
-            if fnmatch(str(fpath), Template(key_match).substitute(params)):
-                # use templating to render any relative paths
-                return Template(local_transformation_script[key_match]).substitute(params)
-        return ""
+    global_transformation_script = config.source_root / 'lfric' / 'lfric_atm' / 'optimisation' / \
+        'meto-spice' / 'global.py'
+    local_transformation_script = config.source_root / 'lfric' / 'lfric_atm' / 'optimisation' / \
+        'meto-spice' / (fpath.relative_to(config.source_root).with_suffix('.py'))
+    if local_transformation_script:
+        return local_transformation_script
+    elif global_transformation_script:
+        return global_transformation_script
     else:
-        # global not defined, local not defined
         return ""
 
 

--- a/run_configs/lfric/gungho.py
+++ b/run_configs/lfric/gungho.py
@@ -27,16 +27,14 @@ def get_transformation_script(fpath, config):
     :rtype: Path
 
     '''
-    global_transformation_script = config.source_root / 'lfric' / 'miniapps' / 'gungho_model' / 'optimisation' / \
-        'meto-spice' / 'global.py'
-    local_transformation_script = config.source_root / 'lfric' / 'miniapps' / 'gungho_model' / 'optimisation' / \
-        'meto-spice' / (fpath.relative_to(config.source_root).with_suffix('.py'))
-    if local_transformation_script:
+    optimisation_path = config.source_root / 'lfric' / 'miniapps' / 'gungho_model' / 'optimisation' / 'meto-spice'
+    local_transformation_script = optimisation_path / (fpath.relative_to(config.source_root).with_suffix('.py'))
+    if local_transformation_script.exists():
         return local_transformation_script
-    elif global_transformation_script:
+    global_transformation_script = optimisation_path / 'global.py'
+    if global_transformation_script.exists():
         return global_transformation_script
-    else:
-        return ""
+    return ""
 
 
 if __name__ == '__main__':

--- a/run_configs/lfric/gungho.py
+++ b/run_configs/lfric/gungho.py
@@ -18,41 +18,24 @@ from fab.steps.psyclone import psyclone, preprocess_x90
 
 from grab_lfric import lfric_source_config, gpl_utils_source_config
 from lfric_common import configurator, fparser_workaround_stop_concatenation
-from fnmatch import fnmatch
-from string import Template
 
 logger = logging.getLogger('fab')
 
 
-def get_transformation_script(fpath):
+def get_transformation_script(fpath, config):
     ''':returns: the transformation script to be used by PSyclone.
     :rtype: Path
 
     '''
-    params = {'relative': fpath.parent, 'source': lfric_source_config.source_root,
-              'output': lfric_source_config.build_output}
-    global_transformation_script = '$source/lfric/miniapps/gungho_model/optimisation/meto-spice/global.py'
-    local_transformation_script = None
-    if global_transformation_script:
-        if local_transformation_script:
-            # global defined, local defined
-            for key_match in local_transformation_script:
-                if fnmatch(str(fpath), Template(key_match).substitute(params)):
-                    # use templating to render any relative paths
-                    return Template(local_transformation_script[key_match]).substitute(params)
-            return Template(global_transformation_script).substitute(params)
-        else:
-            # global defined, local not defined
-            return Template(global_transformation_script).substitute(params)
-    elif local_transformation_script:
-        # global not defined, local defined
-        for key_match in local_transformation_script:
-            if fnmatch(str(fpath), Template(key_match).substitute(params)):
-                # use templating to render any relative paths
-                return Template(local_transformation_script[key_match]).substitute(params)
-        return ""
+    global_transformation_script = config.source_root / 'lfric' / 'miniapps' / 'gungho_model' / 'optimisation' / \
+        'meto-spice' / 'global.py'
+    local_transformation_script = config.source_root / 'lfric' / 'miniapps' / 'gungho_model' / 'optimisation' / \
+        'meto-spice' / (fpath.relative_to(config.source_root).with_suffix('.py'))
+    if local_transformation_script:
+        return local_transformation_script
+    elif global_transformation_script:
+        return global_transformation_script
     else:
-        # global not defined, local not defined
         return ""
 
 

--- a/run_configs/lfric/gungho.py
+++ b/run_configs/lfric/gungho.py
@@ -18,11 +18,42 @@ from fab.steps.psyclone import psyclone, preprocess_x90
 
 from grab_lfric import lfric_source_config, gpl_utils_source_config
 from lfric_common import configurator, fparser_workaround_stop_concatenation
+from fnmatch import fnmatch
+from string import Template
 
 logger = logging.getLogger('fab')
 
 
-# todo: optimisation path stuff
+def get_transformation_script(fpath):
+    ''':returns: the transformation script to be used by PSyclone.
+    :rtype: Path
+
+    '''
+    params = {'relative': fpath.parent, 'source': lfric_source_config.source_root,
+              'output': lfric_source_config.build_output}
+    global_transformation_script = '$source/lfric/miniapps/gungho_model/optimisation/meto-spice/global.py'
+    local_transformation_script = None
+    if global_transformation_script:
+        if local_transformation_script:
+            # global defined, local defined
+            for key_match in local_transformation_script:
+                if fnmatch(str(fpath), Template(key_match).substitute(params)):
+                    # use templating to render any relative paths
+                    return Template(local_transformation_script[key_match]).substitute(params)
+            return Template(global_transformation_script).substitute(params)
+        else:
+            # global defined, local not defined
+            return Template(global_transformation_script).substitute(params)
+    elif local_transformation_script:
+        # global not defined, local defined
+        for key_match in local_transformation_script:
+            if fnmatch(str(fpath), Template(key_match).substitute(params)):
+                # use templating to render any relative paths
+                return Template(local_transformation_script[key_match]).substitute(params)
+        return ""
+    else:
+        # global not defined, local not defined
+        return ""
 
 
 if __name__ == '__main__':
@@ -65,7 +96,7 @@ if __name__ == '__main__':
         psyclone(
             state,
             kernel_roots=[state.build_output],
-            transformation_script=lfric_source / 'miniapps/gungho_model/optimisation/meto-spice/global.py',
+            transformation_script=get_transformation_script,
             cli_args=[],
         )
 

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -386,7 +386,7 @@ def _gen_prebuild_hash(x90_file: Path, mp_payload: MpCommonArgs):
     # calculate the transformation script hash for this file
     transformation_script_hash = 0
     if mp_payload.transformation_script:
-        transformation_script_return_path = mp_payload.transformation_script(x90_file)
+        transformation_script_return_path = mp_payload.transformation_script(fpath=x90_file)  # type: ignore[call-arg]
         if transformation_script_return_path:
             transformation_script_hash = file_checksum(transformation_script_return_path).file_hash
 
@@ -424,7 +424,7 @@ def run_psyclone(generated, modified_alg, x90_file, kernel_roots, transformation
     # transformation python script
     transform_options = []
     if transformation_script:
-        transformation_script_return_path = transformation_script(x90_file)
+        transformation_script_return_path = transformation_script(fpath=x90_file)  # type: ignore[call-arg]
         if transformation_script_return_path:
             transform_options = ['-s', transformation_script_return_path]
 

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -71,7 +71,7 @@ class MpCommonArgs:
     Contains data used to calculate the prebuild hash.
 
     """
-    config: BuildConfig
+    config: Optional[BuildConfig] 
     analysed_x90: Dict[Path, AnalysedX90]
 
     kernel_roots: List[Path]

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -386,7 +386,7 @@ def _gen_prebuild_hash(x90_file: Path, mp_payload: MpCommonArgs):
     # calculate the transformation script hash for this file
     transformation_script_hash = 0
     if mp_payload.transformation_script:
-        transformation_script_return_path = mp_payload.transformation_script(fpath=x90_file)  # type: ignore[call-arg]
+        transformation_script_return_path = mp_payload.transformation_script(x90_file)
         if transformation_script_return_path:
             transformation_script_hash = file_checksum(transformation_script_return_path).file_hash
 
@@ -424,7 +424,7 @@ def run_psyclone(generated, modified_alg, x90_file, kernel_roots, transformation
     # transformation python script
     transform_options = []
     if transformation_script:
-        transformation_script_return_path = transformation_script(fpath=x90_file)  # type: ignore[call-arg]
+        transformation_script_return_path = transformation_script(x90_file)
         if transformation_script_return_path:
             transform_options = ['-s', transformation_script_return_path]
 

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -75,7 +75,7 @@ class MpCommonArgs:
     analysed_x90: Dict[Path, AnalysedX90]
 
     kernel_roots: List[Path]
-    transformation_script: Optional[Callable[[Path],Path]]
+    transformation_script: Optional[Callable[[Path], Path]]
     cli_args: List[str]
 
     all_kernel_hashes: Dict[str, int]
@@ -91,7 +91,7 @@ DEFAULT_SOURCE_GETTER = CollectionConcat([
 
 @step
 def psyclone(config, kernel_roots: Optional[List[Path]] = None,
-             transformation_script: Optional[Callable[[Path],Path]] = None,
+             transformation_script: Optional[Callable[[Path], Path]] = None,
              cli_args: Optional[List[str]] = None,
              source_getter: Optional[ArtefactsGetter] = None,
              overrides_folder: Optional[Path] = None):
@@ -113,7 +113,8 @@ def psyclone(config, kernel_roots: Optional[List[Path]] = None,
     :param kernel_roots:
         Folders containing kernel files. Must be part of the analysed source code.
     :param transformation_script:
-        The function to get Python transformation script. It takes in a file path, and returns the path of the transformation script or none.
+        The function to get Python transformation script.
+        It takes in a file path, and returns the path of the transformation script or none.
     :param cli_args:
         Passed through to the psyclone cli tool.
     :param source_getter:

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -71,7 +71,7 @@ class MpCommonArgs:
     Contains data used to calculate the prebuild hash.
 
     """
-    config: Optional[BuildConfig] 
+    config: BuildConfig
     analysed_x90: Dict[Path, AnalysedX90]
 
     kernel_roots: List[Path]

--- a/tests/system_tests/psyclone/test_psyclone_system_test.py
+++ b/tests/system_tests/psyclone/test_psyclone_system_test.py
@@ -193,7 +193,7 @@ class TestPsyclone(object):
 
 class TestTransformationScript(object):
     """
-    Check whether transformation script is called with x90 file twice
+    Check whether transformation script is called with x90 file once
     and whether transformation script is passed to psyclone after '-s'.
 
     """
@@ -212,8 +212,7 @@ class TestTransformationScript(object):
                          )
 
             # check whether x90 is passed to transformation_script
-            mock_transformation_script.assert_called_with(Path(__file__))
-            assert mock_transformation_script.call_count == 2
+            mock_transformation_script.assert_called_once_with(Path(__file__))
             # check transformation_script is passed to psyclone command with '-s'
             mock_run_command.assert_called_with(['psyclone', '-api', 'dynamo0.3',
                                                  '-l', 'all',

--- a/tests/system_tests/psyclone/test_psyclone_system_test.py
+++ b/tests/system_tests/psyclone/test_psyclone_system_test.py
@@ -17,7 +17,8 @@ from fab.steps.cleanup_prebuilds import cleanup_prebuilds
 from fab.steps.find_source_files import find_source_files
 from fab.steps.grab.folder import grab_folder
 from fab.steps.preprocess import preprocess_fortran
-from fab.steps.psyclone import _analysis_for_prebuilds, make_parsable_x90, preprocess_x90, psyclone, tool_available, run_psyclone
+from fab.steps.psyclone import _analysis_for_prebuilds, make_parsable_x90, preprocess_x90, \
+                               psyclone, tool_available, run_psyclone
 from fab.util import file_checksum
 
 SAMPLE_KERNEL = Path(__file__).parent / 'kernel.f90'
@@ -102,7 +103,7 @@ class Test_analysis_for_prebuilds(object):
                                         kernel_roots=[Path(__file__).parent],
                                         transformation_script=None,
                                         )
-            
+
         # analysed_x90
         assert analysed_x90 == {
             SAMPLE_X90: AnalysedX90(
@@ -189,34 +190,35 @@ class TestPsyclone(object):
         mock_fortran_walk.assert_not_called()
         mock_run.assert_not_called()
 
+
 class TestTransformationScript(object):
     """
-    Check whether transformation script is called with x90 file twice 
+    Check whether transformation script is called with x90 file twice
     and whether transformation script is passed to psyclone after '-s'.
 
     """
     def test_transformation_script(self):
         def dummy_transformation_script(fpath):
             pass
-        mock_transformation_script = mock.create_autospec(dummy_transformation_script, return_value=Path(__file__)) 
+        mock_transformation_script = mock.create_autospec(dummy_transformation_script, return_value=Path(__file__))
         with mock.patch('fab.steps.psyclone.run_command') as mock_run_command:
             mock_transformation_script.return_value = Path(__file__)
             run_psyclone(generated=Path(__file__),
-                         modified_alg=Path(__file__), 
-                         x90_file=Path(__file__), 
-                         kernel_roots=[], 
-                         transformation_script=mock_transformation_script, 
+                         modified_alg=Path(__file__),
+                         x90_file=Path(__file__),
+                         kernel_roots=[],
+                         transformation_script=mock_transformation_script,
                          cli_args=[],
-                        )
+                         )
 
-            # check whether x90 is passed to transformation_script     
+            # check whether x90 is passed to transformation_script
             mock_transformation_script.assert_called_with(Path(__file__))
-            assert mock_transformation_script.call_count==2
-            # check transformation_script is passed to psyclone command with '-s'    
+            assert mock_transformation_script.call_count == 2
+            # check transformation_script is passed to psyclone command with '-s'
             mock_run_command.assert_called_with(['psyclone', '-api', 'dynamo0.3',
                                                  '-l', 'all',
-                                                 '-opsy', Path(__file__),  
+                                                 '-opsy', Path(__file__),
                                                  '-oalg', Path(__file__),
                                                  '-s', Path(__file__),
                                                  Path(__file__),
-                                                ])
+                                                 ])

--- a/tests/system_tests/psyclone/test_psyclone_system_test.py
+++ b/tests/system_tests/psyclone/test_psyclone_system_test.py
@@ -203,10 +203,11 @@ class TestTransformationScript(object):
                          kernel_roots=[],
                          transformation_script=mock_transformation_script,
                          cli_args=[],
+                         config=None,  # type: ignore[arg-type]
                          )
 
             # check whether x90 is passed to transformation_script
-            mock_transformation_script.assert_called_once_with(Path(__file__))
+            mock_transformation_script.assert_called_once_with(Path(__file__), None)
             # check transformation_script is passed to psyclone command with '-s'
             mock_run_command.assert_called_with(['psyclone', '-api', 'dynamo0.3',
                                                  '-l', 'all',

--- a/tests/system_tests/psyclone/test_psyclone_system_test.py
+++ b/tests/system_tests/psyclone/test_psyclone_system_test.py
@@ -96,7 +96,8 @@ class TestX90Analyser(object):
 class Test_analysis_for_prebuilds(object):
 
     def test_analyse(self, tmp_path):
-        with BuildConfig('proj', fab_workspace=tmp_path) as config:
+        with BuildConfig('proj', fab_workspace=tmp_path) as config, \
+             pytest.warns(UserWarning, match="no transformation script specified"):
             analysed_x90, all_kernel_hashes = \
                 _analysis_for_prebuilds(config,
                                         x90s=[SAMPLE_X90],

--- a/tests/system_tests/psyclone/test_psyclone_system_test.py
+++ b/tests/system_tests/psyclone/test_psyclone_system_test.py
@@ -17,8 +17,8 @@ from fab.steps.cleanup_prebuilds import cleanup_prebuilds
 from fab.steps.find_source_files import find_source_files
 from fab.steps.grab.folder import grab_folder
 from fab.steps.preprocess import preprocess_fortran
-from fab.steps.psyclone import _analysis_for_prebuilds, make_parsable_x90, preprocess_x90, psyclone, tool_available, run_psyclone, _gen_prebuild_hash, MpCommonArgs
-from fab.util import file_checksum, string_checksum
+from fab.steps.psyclone import _analysis_for_prebuilds, make_parsable_x90, preprocess_x90, psyclone, tool_available, run_psyclone
+from fab.util import file_checksum
 
 SAMPLE_KERNEL = Path(__file__).parent / 'kernel.f90'
 
@@ -95,40 +95,14 @@ class TestX90Analyser(object):
 class Test_analysis_for_prebuilds(object):
 
     def test_analyse(self, tmp_path):
-
-        # Transformation_script function is supplied by LFRic or other apps, and is not inside Fab. 
-        # Here a dummy function is created for mocking.
-        def dummy_transformation_script(fpath):
-            pass
-
         with BuildConfig('proj', fab_workspace=tmp_path) as config:
-            # the script is just hashed later, so any one will do - use this file!
-            mock_transformation_script = mock.create_autospec(dummy_transformation_script, return_value=Path(__file__))
             analysed_x90, all_kernel_hashes = \
                 _analysis_for_prebuilds(config,
                                         x90s=[SAMPLE_X90],
                                         kernel_roots=[Path(__file__).parent],
-                                        transformation_script=mock_transformation_script,
+                                        transformation_script=None,
                                         )
-            test_mpcommonargs = MpCommonArgs(config=config,
-                                             kernel_roots=[Path(__file__).parent],
-                                             transformation_script=mock_transformation_script,
-                                             cli_args=[],
-                                             analysed_x90=analysed_x90,
-                                             all_kernel_hashes=all_kernel_hashes,
-                                             overrides_folder=None,
-                                             override_files=[],
-                                            )
-            prebuild_hash = _gen_prebuild_hash(x90_file=SAMPLE_X90, mp_payload=test_mpcommonargs)
-
-        # test transformation_script_hash with prebuild_hash
-        # transformation_script_hash is not returned and so is tested with prebuild_hash
-        assert prebuild_hash == sum([analysed_x90[SAMPLE_X90].file_hash,
-                                     sum({all_kernel_hashes[kernel_name] for kernel_name in analysed_x90[SAMPLE_X90].kernel_deps}),
-                                     file_checksum(__file__).file_hash, # transformation_script_hash
-                                     string_checksum(str([]))
-                                    ])
-
+            
         # analysed_x90
         assert analysed_x90 == {
             SAMPLE_X90: AnalysedX90(

--- a/tests/unit_tests/steps/test_psyclone_unit_test.py
+++ b/tests/unit_tests/steps/test_psyclone_unit_test.py
@@ -49,7 +49,8 @@ class Test_gen_prebuild_hash(object):
             analysed_x90=analysed_x90,
             all_kernel_hashes=all_kernel_hashes,
             cli_args=[],
-            config=None, kernel_roots=None, 
+            config=None, 
+            kernel_roots=[], 
             transformation_script=mock_transformation_script,  # type: ignore[arg-type]
             overrides_folder=None, 
             override_files=None,  # type: ignore[arg-type]

--- a/tests/unit_tests/steps/test_psyclone_unit_test.py
+++ b/tests/unit_tests/steps/test_psyclone_unit_test.py
@@ -35,13 +35,8 @@ class Test_gen_prebuild_hash(object):
             'kernel2': 456,
         }
 
-        # Transformation_script function is supplied by LFRic or other apps, and is not inside Fab.
-        # Here a dummy function is created for mocking.
-        def dummy_transformation_script(fpath):
-            pass
         # the script is just hashed later, so any one will do - use this file!
-        mock_transformation_script = mock.create_autospec(dummy_transformation_script,
-                                                          return_value=Path(__file__))
+        mock_transformation_script = mock.Mock(return_value=__file__)
 
         expect_hash = 223133492 + file_checksum(__file__).file_hash  # add the transformation_script_hash
 
@@ -80,7 +75,8 @@ class Test_gen_prebuild_hash(object):
         # changing the transformation script should change the hash
         mp_payload, x90_file, expect_hash = data
         mp_payload.transformation_script = None
-        result = _gen_prebuild_hash(x90_file=x90_file, mp_payload=mp_payload)
+        with pytest.warns(UserWarning, match="no transformation script specified"):
+            result = _gen_prebuild_hash(x90_file=x90_file, mp_payload=mp_payload)
         # transformation_script_hash = 0
         assert result == expect_hash - file_checksum(__file__).file_hash
 

--- a/tests/unit_tests/steps/test_psyclone_unit_test.py
+++ b/tests/unit_tests/steps/test_psyclone_unit_test.py
@@ -12,7 +12,6 @@ import pytest
 from fab.parse.x90 import AnalysedX90
 from fab.steps.psyclone import _check_override, _gen_prebuild_hash, MpCommonArgs
 from fab.util import file_checksum
-from fab.build_config import BuildConfig
 
 
 class Test_gen_prebuild_hash(object):
@@ -36,24 +35,24 @@ class Test_gen_prebuild_hash(object):
             'kernel2': 456,
         }
 
-        # Transformation_script function is supplied by LFRic or other apps, and is not inside Fab. 
+        # Transformation_script function is supplied by LFRic or other apps, and is not inside Fab.
         # Here a dummy function is created for mocking.
         def dummy_transformation_script(fpath):
             pass
         # the script is just hashed later, so any one will do - use this file!
-        mock_transformation_script = mock.create_autospec(dummy_transformation_script, 
+        mock_transformation_script = mock.create_autospec(dummy_transformation_script,
                                                           return_value=Path(__file__))
 
-        expect_hash = 223133492 + file_checksum(__file__).file_hash # add the transformation_script_hash
+        expect_hash = 223133492 + file_checksum(__file__).file_hash  # add the transformation_script_hash
 
         mp_payload = MpCommonArgs(
             analysed_x90=analysed_x90,
             all_kernel_hashes=all_kernel_hashes,
             cli_args=[],
-            config=BuildConfig('proj', fab_workspace=tmp_path), 
-            kernel_roots=[], 
-            transformation_script=mock_transformation_script,  # type: ignore[arg-type]
-            overrides_folder=None, 
+            config=None,  # type: ignore[arg-type]
+            kernel_roots=[],
+            transformation_script=mock_transformation_script,
+            overrides_folder=None,
             override_files=None,  # type: ignore[arg-type]
         )
         return mp_payload, x90_file, expect_hash
@@ -83,7 +82,7 @@ class Test_gen_prebuild_hash(object):
         mp_payload.transformation_script = None
         result = _gen_prebuild_hash(x90_file=x90_file, mp_payload=mp_payload)
         # transformation_script_hash = 0
-        assert result == expect_hash - file_checksum(__file__).file_hash 
+        assert result == expect_hash - file_checksum(__file__).file_hash
 
     def test_cli_args(self, data):
         # changing the cli args should change the hash

--- a/tests/unit_tests/steps/test_psyclone_unit_test.py
+++ b/tests/unit_tests/steps/test_psyclone_unit_test.py
@@ -12,6 +12,7 @@ import pytest
 from fab.parse.x90 import AnalysedX90
 from fab.steps.psyclone import _check_override, _gen_prebuild_hash, MpCommonArgs
 from fab.util import file_checksum
+from fab.build_config import BuildConfig
 
 
 class Test_gen_prebuild_hash(object):
@@ -49,7 +50,7 @@ class Test_gen_prebuild_hash(object):
             analysed_x90=analysed_x90,
             all_kernel_hashes=all_kernel_hashes,
             cli_args=[],
-            config=None, 
+            config=BuildConfig('proj', fab_workspace=tmp_path), 
             kernel_roots=[], 
             transformation_script=mock_transformation_script,  # type: ignore[arg-type]
             overrides_folder=None, 

--- a/tests/unit_tests/steps/test_psyclone_unit_test.py
+++ b/tests/unit_tests/steps/test_psyclone_unit_test.py
@@ -11,6 +11,7 @@ import pytest
 
 from fab.parse.x90 import AnalysedX90
 from fab.steps.psyclone import _check_override, _gen_prebuild_hash, MpCommonArgs
+from fab.util import file_checksum
 
 
 class Test_gen_prebuild_hash(object):
@@ -34,15 +35,24 @@ class Test_gen_prebuild_hash(object):
             'kernel2': 456,
         }
 
-        expect_hash = 223133615
+        # Transformation_script function is supplied by LFRic or other apps, and is not inside Fab. 
+        # Here a dummy function is created for mocking.
+        def dummy_transformation_script(fpath):
+            pass
+        # the script is just hashed later, so any one will do - use this file!
+        mock_transformation_script = mock.create_autospec(dummy_transformation_script, 
+                                                          return_value=Path(__file__))
+
+        expect_hash = 223133492 + file_checksum(__file__).file_hash # add the transformation_script_hash
 
         mp_payload = MpCommonArgs(
             analysed_x90=analysed_x90,
             all_kernel_hashes=all_kernel_hashes,
-            transformation_script_hash=123,
             cli_args=[],
-            config=None, kernel_roots=None, transformation_script=None,  # type: ignore[arg-type]
-            overrides_folder=None, override_files=None,  # type: ignore[arg-type]
+            config=None, kernel_roots=None, 
+            transformation_script=mock_transformation_script,  # type: ignore[arg-type]
+            overrides_folder=None, 
+            override_files=None,  # type: ignore[arg-type]
         )
         return mp_payload, x90_file, expect_hash
 
@@ -68,9 +78,10 @@ class Test_gen_prebuild_hash(object):
     def test_trans_script(self, data):
         # changing the transformation script should change the hash
         mp_payload, x90_file, expect_hash = data
-        mp_payload.transformation_script_hash += 1
+        mp_payload.transformation_script = None
         result = _gen_prebuild_hash(x90_file=x90_file, mp_payload=mp_payload)
-        assert result == expect_hash + 1
+        # transformation_script_hash = 0
+        assert result == expect_hash - file_checksum(__file__).file_hash 
 
     def test_cli_args(self, data):
         # changing the cli args should change the hash


### PR DESCRIPTION
This pull request is related to Issue #18. The purpose is to allow each x90 file to have its specific transformation script. Two files have changed:
1. source/fab/steps/psyclone.py:

The `psyclone` function now takes in a function as the argument for the `transformation_script` parameter. This input function will be written by the user to take in an x90 file path (parameter `fpath`), and return a transformation script path. 

2. tests/system_tests/psyclone/test_psyclone_system_test.py:

Tests have been added to verify that the input transformation script function takes in the x90 file path and returns a transformation script path, which is then passed successfully to the psyclone command with `-s`. The checking for the transformation_script_hash is now done in the unit test, as now the transformation_script_hash is calculated when processing each file. 

3. tests/unit_tests/steps/test_psyclone_unit_test.py:

Transformation_script_hash test and prebuild_hash test have been updated. 
