### PR TITLE
Improve artefact workflow

### DIFF
--- a/docs/source/writing_config.rst
+++ b/docs/source/writing_config.rst
@@ -271,6 +271,41 @@ then creates the executable.
 
 After the :func:`~fab.steps.link.link_exe` step, the executable name can be found in a collection called ``"executables"``.
 
+ArtefactStore
+=============
+Each build configuration contains an artefact store, containing various
+sets of artefacts. The artefact sets used by Fab are defined in the
+enum `ArtefactSet`. The most important sets are `FORTRAN_BUILD_FILES`, 
+`C_BUILD_FILES`, which will always contain all known source files that
+will need to be analysed for dependencies, compiled, and linked. All existing
+steps in Fab will make sure to maintain these artefact sets consistently,
+for example, if a `.F90` file is preprocessed, the `.F90` file in
+`FORTRAN_BUILD_FILES` will be replaced with the corresponding preprocessed
+`.f90` file. Similarly, new files (for examples created by PSyclone)
+will be added to `FORTRAN_BUILD_FILES`). A user script can adds its own
+artefacts using strings as keys if required.
+
+The exact flow of artefact sets is as follows. Note that any artefact
+sets mentioned here can typically be overwritten by the user, but then
+it is the user's responsibility to maintain the default artefact sets
+(or change them all):
+
+..
+  My apologies for the LONG lines, they were the only way I could find
+  to have properly intended paragraphs :(
+
+1. `find_source_files` will add all source files it finds to `ALL_SOURCE` (by default, can be overwritten by the user). Any `.F90` and `.f90` file will also be added to `FORTRAN_BUILD_FILES`, any `.c` file to `C_BUILD_FILES`, and any `.x90` or `.X90` file to `X90_BUILD_FILES`. It can be called several times if files from different root directories need to be added, and it will automatically update the `*_BUILD_FILES` sets.
+2. Any user script that creates new files can add files to `ALL_SOURCE` if required, but also to the corresponding `*_BUILD_FILES`. This will happen automatically if `find_source_files` is called to add these newly created files.
+3. If c_pragma_injector is being called, it will handle all files in `C_BUILD_FILES`, and will replace all the original C files with the newly created ones.
+4. If `preprocess_c` is called, it will preprocess all files in `C_BUILD_FILES` (at this stage typically preprocess the files in the original source folder, writing the output files to the build folder), and update that artefact set accordingly.
+5. If `preprocess_fortran` is called, it will preprocess all files in `FORTRAN_BUILD_FILES` that end on `.F90`, creating new `.f90` files in the build folder. These files will be added to `PREPROCESSED_FORTRAN`. Then the original `.F90` are removed from `FORTRAN_BUILD_FILES`, and the new preprocessed files (which are in `PREPROCESSED_FORTRAN`) will be added. Then any `.f90` files that are not already in the build folder (an example of this are files created by a user script) are copied from the original source folder into the build folder, and `FORTRAN_BUILD_FILES` is updated to use the files in the new location.
+6. If `preprocess_x90` is called, it will similarly preprocess all `.X90` files in `X90_BUILD_FILES`, creating the output files in the build folder, and replacing the files in `X90_BUILD_FILES`.
+7. If `psyclone` is called, it will process all files in `X90_BUILD_FILES` and add any newly created file to `FORTRAN_BUILD_FILES`, and removing them from `X90_BUILD_FILES`.
+8. The `analyse` step analyses all files in `FORTRAN_BUILD_FILES` and `C_BUILD_FILES`, and ad all dependencies to `BUILD_TREES`.
+9. The `compile_c` and `compile_fortran` steps will compile all files from `C_BUILD_FILES` and `FORTRAN_BUILD_FILES`, and add them to `OBJECT_FILES`.
+10. If `archive_objects` is called, it will create libraries based on `OBJECT_FILES`, adding the libraries to `OBJECT_ARCHIVES`.
+11. If `link` is called, it will either use `OBJECT_ARCHIVES`, or if this is empty `OBJECT_FILES`, create the binaries, and add them to `EXECUTABLES`.
+
 
 Flags
 =====

--- a/docs/source/writing_config.rst
+++ b/docs/source/writing_config.rst
@@ -281,7 +281,7 @@ steps in Fab will make sure to maintain these artefact sets consistently,
 for example, if a ``.F90`` file is preprocessed, the ``.F90`` file in
 ``FORTRAN_BUILD_FILES`` will be replaced with the corresponding preprocessed
 ``.f90`` file. Similarly, new files (for examples created by PSyclone)
-will be added to ``FORTRAN_BUILD_FILES``). A user script can adds its own
+will be added to ``FORTRAN_BUILD_FILES``. A user script can adds its own
 artefacts using strings as keys if required.
 
 The exact flow of artefact sets is as follows. Note that any artefact
@@ -295,15 +295,15 @@ it is the user's responsibility to maintain the default artefact sets
 
 1. :func:`~fab.steps.find_source_files.find_source_files` will add all source files it finds to ``ALL_SOURCE`` (by default, can be overwritten by the user). Any ``.F90`` and ``.f90`` file will also be added to ``FORTRAN_BUILD_FILES``, any ``.c`` file to ``C_BUILD_FILES``, and any ``.x90`` or ``.X90`` file to ``X90_BUILD_FILES``. It can be called several times if files from different root directories need to be added, and it will automatically update the ``*_BUILD_FILES`` sets.
 2. Any user script that creates new files can add files to ``ALL_SOURCE`` if required, but also to the corresponding ``*_BUILD_FILES``. This will happen automatically if :func:`~fab.steps.find_source_files.find_source_files` is called to add these newly created files.
-3. If :func:`~fab.steps.c_pragma_injector.c_pragma_injector` is being called, it will handle all files in ``C_BUILD_FILES``, and will replace all the original C files with the newly created ones.
-4. If :func:`~fab.steps.preprocess.preprocess_c` is called, it will preprocess all files in ``C_BUILD_FILES`` (at this stage typically preprocess the files in the original source folder, writing the output files to the build folder), and update that artefact set accordingly.
+3. If :func:`~fab.steps.c_pragma_injector.c_pragma_injector` is being called, it will handle all files in ``C_BUILD_FILES``, and will replace all the original C files with the newly created ones. For backward compatibility it will also store the new objects in the ``PRAGMAD_C`` set.
+4. If :func:`~fab.steps.preprocess.preprocess_c` is called, it will preprocess all files in ``C_BUILD_FILES`` (at this stage typically preprocess the files in the original source folder, writing the output files to the build folder), and update that artefact set accordingly. For backward compatibility it will also store the preprocessed files in ``PREPROCESSED_C``.
 5. If :func:`~fab.steps.preprocess.preprocess_fortran` is called, it will preprocess all files in ``FORTRAN_BUILD_FILES`` that end on ``.F90``, creating new ``.f90`` files in the build folder. These files will be added to ``PREPROCESSED_FORTRAN``. Then the original ``.F90`` are removed from ``FORTRAN_BUILD_FILES``, and the new preprocessed files (which are in ``PREPROCESSED_FORTRAN``) will be added. Then any ``.f90`` files that are not already in the build folder (an example of this are files created by a user script) are copied from the original source folder into the build folder, and ``FORTRAN_BUILD_FILES`` is updated to use the files in the new location.
 6. If :func:`~fab.steps.psyclone.preprocess_x90` is called, it will similarly preprocess all ``.X90`` files in ``X90_BUILD_FILES``, creating the output files in the build folder, and replacing the files in ``X90_BUILD_FILES``.
 7. If :func:`~fab.steps.psyclone.psyclone` is called, it will process all files in ``X90_BUILD_FILES`` and add any newly created file to ``FORTRAN_BUILD_FILES``, and removing them from ``X90_BUILD_FILES``.
 8. The :func:`~fab.steps.analyse.analyse` step analyses all files in ``FORTRAN_BUILD_FILES`` and ``C_BUILD_FILES``, and add all dependencies to ``BUILD_TREES``.
 9. The :func:`~fab.steps.compile_c.compile_c` and :func:`~fab.steps.compile_fortran.compile_fortran` steps will compile all files from ``C_BUILD_FILES`` and ``FORTRAN_BUILD_FILES``, and add them to ``OBJECT_FILES``.
 10. If :func:`~fab.steps.archive_objects.archive_objects` is called, it will create libraries based on ``OBJECT_FILES``, adding the libraries to ``OBJECT_ARCHIVES``.
-11. If :func:`~fab.steps.link.link_exe` is called, it will either use ``OBJECT_ARCHIVES``, or if this is empty ``OBJECT_FILES``, create the binaries, and add them to ``EXECUTABLES``.
+11. If :func:`~fab.steps.link.link_exe` is called, it will either use ``OBJECT_ARCHIVES``, or if this is empty, use ``OBJECT_FILES``, create the binaries, and add them to ``EXECUTABLES``.
 
 
 Flags

--- a/docs/source/writing_config.rst
+++ b/docs/source/writing_config.rst
@@ -79,7 +79,7 @@ Please see the documentation for :func:`~fab.steps.find_source_files.find_source
 including how to exclude certain source code from the build. More grab steps can be found in the :mod:`~fab.steps.grab`
 module.
 
-After the find_source_files step, there will be a collection called ``"all_source"``, in the artefact store.
+After the find_source_files step, there will be a collection called ``"ALL_SOURCE"``, in the artefact store.
 
 .. [1] See :func:`~fab.steps.c_pragma_injector.c_pragma_injector` for an example of a step which
     creates artefacts in the source folder.
@@ -94,7 +94,7 @@ which must happen before we analyse it.
 
 Steps generally create and find artefacts in the :term:`Artefact Store`, arranged into named collections.
 The :func:`~fab.steps.preprocess.preprocess_fortran`
-automatically looks for Fortran source code in a collection named `'all_source'`,
+automatically looks for Fortran source code in a collection named `'ALL_SOURCE'`,
 which is the default output from the preceding :funcfind_source_files step.
 It filters just the (uppercase) ``.F90`` files.
 
@@ -179,7 +179,7 @@ before you run the :func:`~fab.steps.analyse.analyse` step below.
 
 
 After the psyclone step, two new source files will be created for each .x90 file in the `'build_output'` folder.
-These two output files will be added under ``"psyclone_output"`` collection to the artefact store.
+These two output files will be added under ``FORTRAN_BUILD_FILES`` collection to the artefact store.
 
 
 .. _Analyse Overview:
@@ -190,11 +190,10 @@ Analyse
 We must :func:`~fab.steps.analyse.analyse` the source code to determine which
 Fortran files to compile, and in which order.
 
-The Analyse step looks for source to analyse in several collections:
+The Analyse step looks for source to analyse in two collections:
 
-* ``.f90`` found in the source
-* ``.F90`` we pre-processed into ``.f90``
-* preprocessed c
+* ``FORTRAN_BUILD_FILES``, which contains all ``.f90`` found in the source, all ``.F90`` files we pre-processed into ``.f90``, and files created by any additional step (e.g. PSyclone).
+* ``C_BUILD_FILES``, all preprocessed c files.
 
 .. code-block::
     :linenos:
@@ -227,14 +226,14 @@ The Analyse step looks for source to analyse in several collections:
 Here we tell the analyser which :term:`Root Symbol` we want to build into an executable.
 Alternatively, we can use the ``find_programs`` flag for Fab to discover and build all programs.
 
-After the Analyse step, there will be a collection called ``"build_trees"``, in the artefact store.
+After the Analyse step, there will be a collection called ``BUILD_TREES``, in the artefact store.
 
 
 Compile and Link
 ================
 
 The :func:`~fab.steps.compile_fortran.compile_fortran` step compiles files in
-the ``"build_trees"`` collection. The :func:`~fab.steps.link.link_exe` step
+the ``BUILD_TREES`` collection. The :func:`~fab.steps.link.link_exe` step
 then creates the executable.
 
 .. code-block::
@@ -269,20 +268,20 @@ then creates the executable.
             link_exe(state)
 
 
-After the :func:`~fab.steps.link.link_exe` step, the executable name can be found in a collection called ``"executables"``.
+After the :func:`~fab.steps.link.link_exe` step, the executable name can be found in a collection called ``EXECUTABLES``.
 
 ArtefactStore
 =============
 Each build configuration contains an artefact store, containing various
 sets of artefacts. The artefact sets used by Fab are defined in the
-enum `ArtefactSet`. The most important sets are `FORTRAN_BUILD_FILES`, 
-`C_BUILD_FILES`, which will always contain all known source files that
+enum :class:`~fab.artefacts.ArtefactSet`. The most important sets are ``FORTRAN_BUILD_FILES``, 
+``C_BUILD_FILES``, which will always contain all known source files that
 will need to be analysed for dependencies, compiled, and linked. All existing
 steps in Fab will make sure to maintain these artefact sets consistently,
-for example, if a `.F90` file is preprocessed, the `.F90` file in
-`FORTRAN_BUILD_FILES` will be replaced with the corresponding preprocessed
-`.f90` file. Similarly, new files (for examples created by PSyclone)
-will be added to `FORTRAN_BUILD_FILES`). A user script can adds its own
+for example, if a ``.F90`` file is preprocessed, the ``.F90`` file in
+``FORTRAN_BUILD_FILES`` will be replaced with the corresponding preprocessed
+``.f90`` file. Similarly, new files (for examples created by PSyclone)
+will be added to ``FORTRAN_BUILD_FILES``). A user script can adds its own
 artefacts using strings as keys if required.
 
 The exact flow of artefact sets is as follows. Note that any artefact
@@ -294,17 +293,17 @@ it is the user's responsibility to maintain the default artefact sets
   My apologies for the LONG lines, they were the only way I could find
   to have properly indented paragraphs :(
 
-1. `find_source_files` will add all source files it finds to `ALL_SOURCE` (by default, can be overwritten by the user). Any `.F90` and `.f90` file will also be added to `FORTRAN_BUILD_FILES`, any `.c` file to `C_BUILD_FILES`, and any `.x90` or `.X90` file to `X90_BUILD_FILES`. It can be called several times if files from different root directories need to be added, and it will automatically update the `*_BUILD_FILES` sets.
-2. Any user script that creates new files can add files to `ALL_SOURCE` if required, but also to the corresponding `*_BUILD_FILES`. This will happen automatically if `find_source_files` is called to add these newly created files.
-3. If c_pragma_injector is being called, it will handle all files in `C_BUILD_FILES`, and will replace all the original C files with the newly created ones.
-4. If `preprocess_c` is called, it will preprocess all files in `C_BUILD_FILES` (at this stage typically preprocess the files in the original source folder, writing the output files to the build folder), and update that artefact set accordingly.
-5. If `preprocess_fortran` is called, it will preprocess all files in `FORTRAN_BUILD_FILES` that end on `.F90`, creating new `.f90` files in the build folder. These files will be added to `PREPROCESSED_FORTRAN`. Then the original `.F90` are removed from `FORTRAN_BUILD_FILES`, and the new preprocessed files (which are in `PREPROCESSED_FORTRAN`) will be added. Then any `.f90` files that are not already in the build folder (an example of this are files created by a user script) are copied from the original source folder into the build folder, and `FORTRAN_BUILD_FILES` is updated to use the files in the new location.
-6. If `preprocess_x90` is called, it will similarly preprocess all `.X90` files in `X90_BUILD_FILES`, creating the output files in the build folder, and replacing the files in `X90_BUILD_FILES`.
-7. If `psyclone` is called, it will process all files in `X90_BUILD_FILES` and add any newly created file to `FORTRAN_BUILD_FILES`, and removing them from `X90_BUILD_FILES`.
-8. The `analyse` step analyses all files in `FORTRAN_BUILD_FILES` and `C_BUILD_FILES`, and ad all dependencies to `BUILD_TREES`.
-9. The `compile_c` and `compile_fortran` steps will compile all files from `C_BUILD_FILES` and `FORTRAN_BUILD_FILES`, and add them to `OBJECT_FILES`.
-10. If `archive_objects` is called, it will create libraries based on `OBJECT_FILES`, adding the libraries to `OBJECT_ARCHIVES`.
-11. If `link` is called, it will either use `OBJECT_ARCHIVES`, or if this is empty `OBJECT_FILES`, create the binaries, and add them to `EXECUTABLES`.
+1. :func:`~fab.steps.find_source_files.find_source_files` will add all source files it finds to ``ALL_SOURCE`` (by default, can be overwritten by the user). Any ``.F90`` and ``.f90`` file will also be added to ``FORTRAN_BUILD_FILES``, any ``.c`` file to ``C_BUILD_FILES``, and any ``.x90`` or ``.X90`` file to ``X90_BUILD_FILES``. It can be called several times if files from different root directories need to be added, and it will automatically update the ``*_BUILD_FILES`` sets.
+2. Any user script that creates new files can add files to ``ALL_SOURCE`` if required, but also to the corresponding ``*_BUILD_FILES``. This will happen automatically if :func:`~fab.steps.find_source_files.find_source_files` is called to add these newly created files.
+3. If :func:`~fab.steps.c_pragma_injector.c_pragma_injector` is being called, it will handle all files in ``C_BUILD_FILES``, and will replace all the original C files with the newly created ones.
+4. If :func:`~fab.steps.preprocess.preprocess_c` is called, it will preprocess all files in ``C_BUILD_FILES`` (at this stage typically preprocess the files in the original source folder, writing the output files to the build folder), and update that artefact set accordingly.
+5. If :func:`~fab.steps.preprocess.preprocess_fortran` is called, it will preprocess all files in ``FORTRAN_BUILD_FILES`` that end on ``.F90``, creating new ``.f90`` files in the build folder. These files will be added to ``PREPROCESSED_FORTRAN``. Then the original ``.F90`` are removed from ``FORTRAN_BUILD_FILES``, and the new preprocessed files (which are in ``PREPROCESSED_FORTRAN``) will be added. Then any ``.f90`` files that are not already in the build folder (an example of this are files created by a user script) are copied from the original source folder into the build folder, and ``FORTRAN_BUILD_FILES`` is updated to use the files in the new location.
+6. If :func:`~fab.steps.psyclone.preprocess_x90` is called, it will similarly preprocess all ``.X90`` files in ``X90_BUILD_FILES``, creating the output files in the build folder, and replacing the files in ``X90_BUILD_FILES``.
+7. If :func:`~fab.steps.psyclone.psyclone` is called, it will process all files in ``X90_BUILD_FILES`` and add any newly created file to ``FORTRAN_BUILD_FILES``, and removing them from ``X90_BUILD_FILES``.
+8. The :func:`~fab.steps.analyse.analyse` step analyses all files in ``FORTRAN_BUILD_FILES`` and ``C_BUILD_FILES``, and add all dependencies to ``BUILD_TREES``.
+9. The :func:`~fab.steps.compile_c.compile_c` and :func:`~fab.steps.compile_fortran.compile_fortran` steps will compile all files from ``C_BUILD_FILES`` and ``FORTRAN_BUILD_FILES``, and add them to ``OBJECT_FILES``.
+10. If :func:`~fab.steps.archive_objects.archive_objects` is called, it will create libraries based on ``OBJECT_FILES``, adding the libraries to ``OBJECT_ARCHIVES``.
+11. If :func:`~fab.steps.link.link_exe` is called, it will either use ``OBJECT_ARCHIVES``, or if this is empty ``OBJECT_FILES``, create the binaries, and add them to ``EXECUTABLES``.
 
 
 Flags

--- a/docs/source/writing_config.rst
+++ b/docs/source/writing_config.rst
@@ -292,7 +292,7 @@ it is the user's responsibility to maintain the default artefact sets
 
 ..
   My apologies for the LONG lines, they were the only way I could find
-  to have properly intended paragraphs :(
+  to have properly indented paragraphs :(
 
 1. `find_source_files` will add all source files it finds to `ALL_SOURCE` (by default, can be overwritten by the user). Any `.F90` and `.f90` file will also be added to `FORTRAN_BUILD_FILES`, any `.c` file to `C_BUILD_FILES`, and any `.x90` or `.X90` file to `X90_BUILD_FILES`. It can be called several times if files from different root directories need to be added, and it will automatically update the `*_BUILD_FILES` sets.
 2. Any user script that creates new files can add files to `ALL_SOURCE` if required, but also to the corresponding `*_BUILD_FILES`. This will happen automatically if `find_source_files` is called to add these newly created files.

--- a/run_configs/lfric/atm.py
+++ b/run_configs/lfric/atm.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+
+'''Example LFRic_atm build script.
+'''
+
 import logging
 
 from fab.build_config import BuildConfig, AddFlags
@@ -16,7 +20,8 @@ from fab.steps.find_source_files import find_source_files, Exclude, Include
 from fab.tools import ToolBox
 
 from grab_lfric import lfric_source_config, gpl_utils_source_config
-from lfric_common import configurator, fparser_workaround_stop_concatenation
+from lfric_common import (configurator, fparser_workaround_stop_concatenation,
+                          get_transformation_script)
 
 logger = logging.getLogger('fab')
 
@@ -160,26 +165,6 @@ def file_filtering(config):
         Exclude(science_root / 'shumlib')
 
     ]
-
-
-def get_transformation_script(fpath, config):
-    ''':returns: the transformation script to be used by PSyclone.
-    :rtype: Path
-
-    '''
-    optimisation_path = config.source_root / 'optimisation' / 'meto-spice'
-    for base_path in [config.source_root, config.build_output]:
-        try:
-            relative_path = fpath.relative_to(base_path)
-        except ValueError:
-            pass
-    local_transformation_script = optimisation_path / (relative_path.with_suffix('.py'))
-    if local_transformation_script.exists():
-        return local_transformation_script
-    global_transformation_script = optimisation_path / 'global.py'
-    if global_transformation_script.exists():
-        return global_transformation_script
-    return ""
 
 
 if __name__ == '__main__':

--- a/run_configs/lfric/gungho.py
+++ b/run_configs/lfric/gungho.py
@@ -4,6 +4,10 @@
 #  For further details please refer to the file COPYRIGHT
 #  which you should have received as part of this distribution
 # ##############################################################################
+'''
+A simple build script for gungho_model
+'''
+
 import logging
 
 from fab.build_config import BuildConfig
@@ -18,29 +22,10 @@ from fab.steps.psyclone import psyclone, preprocess_x90
 from fab.tools import ToolBox
 
 from grab_lfric import lfric_source_config, gpl_utils_source_config
-from lfric_common import configurator, fparser_workaround_stop_concatenation
+from lfric_common import (configurator, fparser_workaround_stop_concatenation,
+                          get_transformation_script)
 
 logger = logging.getLogger('fab')
-
-
-def get_transformation_script(fpath, config):
-    ''':returns: the transformation script to be used by PSyclone.
-    :rtype: Path
-
-    '''
-    optimisation_path = config.source_root / 'optimisation' / 'meto-spice'
-    for base_path in [config.source_root, config.build_output]:
-        try:
-            relative_path = fpath.relative_to(base_path)
-        except ValueError:
-            pass
-    local_transformation_script = optimisation_path / (relative_path.with_suffix('.py'))
-    if local_transformation_script.exists():
-        return local_transformation_script
-    global_transformation_script = optimisation_path / 'global.py'
-    if global_transformation_script.exists():
-        return global_transformation_script
-    return ""
 
 
 if __name__ == '__main__':

--- a/run_configs/lfric/lfric_common.py
+++ b/run_configs/lfric/lfric_common.py
@@ -71,13 +71,9 @@ def configurator(config, lfric_source: Path, gpl_utils_source: Path, rose_meta_c
         ]
     )
 
-    # put the generated source into an artefact
-    # todo: we shouldn't need to do this, should we?
-    #       it's just going to be found in the source folder with everything else.
-    config._artefact_store['configurator_output'] = [
-        configuration_mod_fpath,
-        feign_config_mod_fpath
-    ]
+    config._artefact_store.add(ArtefactSet.FORTRAN_BUILD_FILES,
+                               [configuration_mod_fpath,
+                                feign_config_mod_fpath ])
 
 
 @step

--- a/run_configs/lfric/lfric_common.py
+++ b/run_configs/lfric/lfric_common.py
@@ -30,7 +30,6 @@ def configurator(config, lfric_source: Path, gpl_utils_source: Path, rose_meta_c
     gen_namelist_tool = lfric_source / 'infrastructure/build/tools/GenerateNamelist'
     gen_loader_tool = lfric_source / 'infrastructure/build/tools/GenerateLoader'
     gen_feigns_tool = lfric_source / 'infrastructure/build/tools/GenerateFeigns'
-
     config_dir = config_dir or config.source_root / 'configuration'
     config_dir.mkdir(parents=True, exist_ok=True)
 
@@ -44,7 +43,7 @@ def configurator(config, lfric_source: Path, gpl_utils_source: Path, rose_meta_c
     # gungho/build
     logger.info('rose_picker')
     rose_picker = Script(rose_picker_tool)
-    rose_picker.run(additional_parameters=[str(rose_meta_conf),
+    rose_picker.run(additional_parameters=[rose_meta_conf,
                                            '-directory', config_dir,
                                            '-include_dirs', lfric_source],
                     env=env)

--- a/run_configs/lfric/lfric_common.py
+++ b/run_configs/lfric/lfric_common.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from fab.artefacts import ArtefactSet
 from fab.steps import step
+from fab.steps.find_source_files import find_source_files
 from fab.tools import Categories, Tool
 
 logger = logging.getLogger('fab')
@@ -22,7 +23,6 @@ class Script(Tool):
         return True
 
 
-# todo: is this part of psyclone? if so, put  it in the psyclone step module?
 @step
 def configurator(config, lfric_source: Path, gpl_utils_source: Path, rose_meta_conf: Path, config_dir=None):
 
@@ -32,65 +32,78 @@ def configurator(config, lfric_source: Path, gpl_utils_source: Path, rose_meta_c
     gen_feigns_tool = lfric_source / 'infrastructure/build/tools/GenerateFeigns'
 
     config_dir = config_dir or config.source_root / 'configuration'
+    config_dir.mkdir(parents=True, exist_ok=True)
 
     env = os.environ.copy()
     rose_lfric_path = gpl_utils_source / 'lib/python'
     env['PYTHONPATH'] += f':{rose_lfric_path}'
 
-    # "rose picker"
-    # creates rose-meta.json and config_namelists.txt in gungho/source/configuration
+    # rose picker
+    # -----------
+    # creates rose-meta.json and config_namelists.txt in
+    # gungho/build
     logger.info('rose_picker')
     rose_picker = Script(rose_picker_tool)
     rose_picker.run(additional_parameters=[str(rose_meta_conf),
-                                           '-directory', str(config_dir),
+                                           '-directory', config_dir,
                                            '-include_dirs', lfric_source],
                     env=env)
+    rose_meta = config_dir / 'rose-meta.json'
 
-    # "build_config_loaders"
+    # build_config_loaders
+    # --------------------
     # builds a bunch of f90s from the json
     logger.info('GenerateNamelist')
     gen_namelist = Script(gen_namelist_tool)
-    gen_namelist.run(additional_parameters=['-verbose',
-                                            str(config_dir / 'rose-meta.json'),
-                                            '-directory', str(config_dir)])
+    gen_namelist.run(additional_parameters=['-verbose', rose_meta,
+                                            '-directory', config_dir],
+                     cwd=config_dir)
 
     # create configuration_mod.f90 in source root
+    # -------------------------------------------
     logger.info('GenerateLoader')
+    names = [name.strip() for name in
+             open(config_dir / 'config_namelists.txt').readlines()]
+    configuration_mod_fpath = config_dir / 'configuration_mod.f90'
     gen_loader = Script(gen_loader_tool)
-    names = [name.strip() for name in open(config_dir / 'config_namelists.txt').readlines()]
-    configuration_mod_fpath = config.source_root / 'configuration_mod.f90'
     gen_loader.run(additional_parameters=[configuration_mod_fpath,
                                           *names])
 
     # create feign_config_mod.f90 in source root
+    # ------------------------------------------
     logger.info('GenerateFeigns')
-    feign_config = Script(gen_feigns_tool)
-    feign_config_mod_fpath = config.source_root / 'feign_config_mod.f90'
-    feign_config.run(additional_parameters=[str(config_dir / 'rose-meta.json'),
-                                            '-output', feign_config_mod_fpath])
+    feign_config_mod_fpath = config_dir / 'feign_config_mod.f90'
+    gft = Script(gen_feigns_tool)
+    gft.run(additional_parameters=[rose_meta,
+                                   '-output', feign_config_mod_fpath])
 
-    config._artefact_store.add(ArtefactSet.FORTRAN_BUILD_FILES,
-                               [configuration_mod_fpath,
-                                feign_config_mod_fpath])
+    find_source_files(config, source_root=config_dir)
 
 
 @step
 def fparser_workaround_stop_concatenation(config):
     """
-    fparser can't handle string concat in a stop statement. This step is a workaround.
+    fparser can't handle string concat in a stop statement. This step is
+    a workaround.
 
     https://github.com/stfc/fparser/issues/330
 
     """
-    feign_config_mod_fpath = config.source_root / 'feign_config_mod.f90'
+    feign_path = None
+    for file_path in config.artefact_store[ArtefactSet.FORTRAN_BUILD_FILES]:
+        if file_path.name == 'feign_config_mod.f90':
+            feign_path = file_path
+            break
+    else:
+        raise RuntimeError("Could not find 'feign_config_mod.f90'.")
 
     # rename "broken" version
-    broken_version = feign_config_mod_fpath.with_suffix('.broken')
-    shutil.move(feign_config_mod_fpath, broken_version)
+    broken_version = feign_path.with_suffix('.broken')
+    shutil.move(feign_path, broken_version)
 
     # make fixed version
     bad = "_config: '// &\n        'Unable to close temporary file'"
     good = "_config: Unable to close temporary file'"
 
-    open(feign_config_mod_fpath, 'wt').write(
+    open(feign_path, 'wt').write(
         open(broken_version, 'rt').read().replace(bad, good))

--- a/run_configs/lfric/lfric_common.py
+++ b/run_configs/lfric/lfric_common.py
@@ -23,6 +23,7 @@ class Script(Tool):
         return True
 
 
+# ============================================================================
 @step
 def configurator(config, lfric_source: Path, gpl_utils_source: Path, rose_meta_conf: Path, config_dir=None):
 
@@ -79,6 +80,7 @@ def configurator(config, lfric_source: Path, gpl_utils_source: Path, rose_meta_c
     find_source_files(config, source_root=config_dir)
 
 
+# ============================================================================
 @step
 def fparser_workaround_stop_concatenation(config):
     """
@@ -106,3 +108,28 @@ def fparser_workaround_stop_concatenation(config):
 
     open(feign_path, 'wt').write(
         open(broken_version, 'rt').read().replace(bad, good))
+
+
+# ============================================================================
+def get_transformation_script(fpath, config):
+    ''':returns: the transformation script to be used by PSyclone.
+    :rtype: Path
+
+    '''
+    optimisation_path = config.source_root / 'optimisation' / 'meto-spice'
+    relative_path = None
+    for base_path in [config.source_root, config.build_output]:
+        try:
+            relative_path = fpath.relative_to(base_path)
+        except ValueError:
+            pass
+    if relative_path:
+        local_transformation_script = (optimisation_path /
+                                       (relative_path.with_suffix('.py')))
+        if local_transformation_script.exists():
+            return local_transformation_script
+
+    global_transformation_script = optimisation_path / 'global.py'
+    if global_transformation_script.exists():
+        return global_transformation_script
+    return ""

--- a/run_configs/lfric/lfric_common.py
+++ b/run_configs/lfric/lfric_common.py
@@ -71,7 +71,7 @@ def configurator(config, lfric_source: Path, gpl_utils_source: Path, rose_meta_c
 
     config._artefact_store.add(ArtefactSet.FORTRAN_BUILD_FILES,
                                [configuration_mod_fpath,
-                                feign_config_mod_fpath ])
+                                feign_config_mod_fpath])
 
 
 @step

--- a/run_configs/lfric/lfric_common.py
+++ b/run_configs/lfric/lfric_common.py
@@ -3,6 +3,7 @@ import os
 import shutil
 from pathlib import Path
 
+from fab.artefacts import ArtefactSet
 from fab.steps import step
 from fab.tools import Categories, Tool
 

--- a/run_configs/um/build_um.py
+++ b/run_configs/um/build_um.py
@@ -13,9 +13,8 @@ import os
 import re
 import warnings
 
-from fab.artefacts import CollectionGetter
+from fab.artefacts import ArtefactSet, CollectionGetter
 from fab.build_config import AddFlags, BuildConfig
-from fab.constants import PRAGMAD_C
 from fab.steps import step
 from fab.steps.analyse import analyse
 from fab.steps.archive_objects import archive_objects
@@ -177,7 +176,7 @@ if __name__ == '__main__':
 
         preprocess_c(
             state,
-            source=CollectionGetter(PRAGMAD_C),
+            source=CollectionGetter(ArtefactSet.PRAGMAD_C),
             path_flags=[
                 # todo: this is a bit "codey" - can we safely give longer strings and split later?
                 AddFlags(match="$source/um/*", flags=[

--- a/run_configs/um/build_um.py
+++ b/run_configs/um/build_um.py
@@ -176,7 +176,7 @@ if __name__ == '__main__':
 
         preprocess_c(
             state,
-            source=CollectionGetter(ArtefactSet.PRAGMAD_C),
+            source=CollectionGetter(ArtefactSet.C_BUILD_FILES),
             path_flags=[
                 # todo: this is a bit "codey" - can we safely give longer strings and split later?
                 AddFlags(match="$source/um/*", flags=[

--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -108,6 +108,27 @@ class ArtefactStore(dict):
         else:
             self.add(dest, self[source])
 
+    def replace(self, artefact: Union[str, ArtefactSet],
+                remove_files: List[str],
+                add_files: Union[List[str], dict]):
+        '''Replaces artefacts in one artefact set with other artefacts. This
+        can be used e.g to replace files that have been preprocessed
+        and renamed. There is no requirement for these lists to have the
+        same number of elements, nor is there any check if an artefact to
+        be removed is actually in the artefact set.
+
+        :param artefact: the artefact set to modify.
+        :param remove_files: files to remove from the artefact set.
+        :param add_files: files to add to the artefact set.
+        '''
+
+        art_set = self[artefact]
+        if not isinstance(art_set, set):
+            raise RuntimeError(f"Replacing artefacts in dictionary "
+                               f"'{artefact}' is not supported.")
+        art_set.difference_update(set(remove_files))
+        art_set.update(add_files)
+
 
 class ArtefactsGetter(ABC):
     """
@@ -143,7 +164,7 @@ class CollectionGetter(ArtefactsGetter):
         self.collection_name = collection_name
 
     def __call__(self, artefact_store):
-        return artefact_store.get(self.collection_name, [])
+        return artefact_store.get(self.collection_name, set())
 
 
 class CollectionConcat(ArtefactsGetter):

--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -18,7 +18,7 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from enum import auto, Enum
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Set, Union
+from typing import Dict, Iterable, List, Optional, Union
 
 from fab.dep_tree import filter_source_tree, AnalysedDependent
 from fab.util import suffix_filter
@@ -66,7 +66,7 @@ class ArtefactStore(dict):
                 self[artefact] = set()
 
     def add(self, collection: Union[str, ArtefactSet],
-            files: Union[str, List[str], Set[str]]):
+            files: Union[Path, str, Iterable[Path], Iterable[str]]):
         '''Adds the specified artefacts to a collection. The artefact
         can be specified as a simple string, a list of string or a set, in
         which case all individual entries of the list/set will be added.
@@ -75,7 +75,7 @@ class ArtefactStore(dict):
         '''
         if isinstance(files, list):
             files = set(files)
-        elif not isinstance(files, set):
+        elif not isinstance(files, Iterable):
             # We need to use a list, otherwise each character is added
             files = set([files])
 
@@ -110,8 +110,8 @@ class ArtefactStore(dict):
             self.add(dest, self[source])
 
     def replace(self, artefact: Union[str, ArtefactSet],
-                remove_files: List[str],
-                add_files: Union[List[str], dict]):
+                remove_files: List[Union[str, Path]],
+                add_files: Union[List[Union[str, Path]], dict]):
         '''Replaces artefacts in one artefact set with other artefacts. This
         can be used e.g to replace files that have been preprocessed
         and renamed. There is no requirement for these lists to have the

--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -57,7 +57,8 @@ class ArtefactStore(dict):
         '''
         self.clear()
         for artefact in ArtefactSet:
-            if artefact == ArtefactSet.OBJECT_FILES:
+            if artefact in [ArtefactSet.OBJECT_FILES,
+                            ArtefactSet.OBJECT_ARCHIVES]:
                 # ObjectFiles store a default dictionary (i.e. a non-existing
                 # key will automatically add an empty `set`)
                 self[artefact] = defaultdict(set)
@@ -81,14 +82,14 @@ class ArtefactStore(dict):
         self[collection].update(files)
 
     def update_dict(self, collection: Union[str, ArtefactSet],
-                    key: str, values: set):
+                    key: str, values: Union[str, set]):
         '''For ArtefactSets that are a dictionary of sets: update
         the set with the specified values.
         :param collection: the name of the collection to add this to.
         :param key: the key in the dictionary to update.
         :param values: the values to update with.
         '''
-        self[collection][key].update(values)
+        self[collection][key].update([values] if isinstance(values, str) else values)
 
     def copy_artefacts(self, source: Union[str, ArtefactSet],
                        dest: Union[str, ArtefactSet],
@@ -104,7 +105,7 @@ class ArtefactStore(dict):
         '''
         if suffixes:
             suffixes = [suffixes] if isinstance(suffixes, str) else suffixes
-            self.add(dest, suffix_filter(self[source], suffixes))
+            self.add(dest, set(suffix_filter(self[source], suffixes)))
         else:
             self.add(dest, self[source])
 

--- a/source/fab/artefacts.py
+++ b/source/fab/artefacts.py
@@ -82,7 +82,7 @@ class ArtefactStore(dict):
         self[collection].update(files)
 
     def update_dict(self, collection: Union[str, ArtefactSet],
-                    key: str, values: Union[str, set]):
+                    key: str, values: Union[str, Iterable]):
         '''For ArtefactSets that are a dictionary of sets: update
         the set with the specified values.
         :param collection: the name of the collection to add this to.
@@ -99,7 +99,7 @@ class ArtefactStore(dict):
         will be copied.
 
         :param source: the source artefact set.
-        :param dest: the source artefact set.
+        :param dest: the destination artefact set.
         :param suffixes: a string or list of strings specifying the
             suffixes to copy.
         '''

--- a/source/fab/cli.py
+++ b/source/fab/cli.py
@@ -51,7 +51,7 @@ def _generic_build_config(folder: Path, kwargs=None) -> BuildConfig:
         root_inc_files(config)  # JULES helper, get rid of this eventually
         preprocess_fortran(config)
         c_pragma_injector(config)
-        preprocess_c(config, source=CollectionGetter(ArtefactSet.PRAGMAD_C))
+        preprocess_c(config, source=CollectionGetter(ArtefactSet.C_BUILD_FILES))
         analyse(config, find_programs=True)
         compile_fortran(config)
         compile_c(config)

--- a/source/fab/parse/fortran.py
+++ b/source/fab/parse/fortran.py
@@ -301,7 +301,11 @@ class FortranAnalyser(FortranAnalyserBase):
             # TODO #13: once fparser supports reading the sentinels,
             # this can be removed.
             reader = FortranStringReader(comment[2:])
-            line = reader.next()
+            try:
+                line = reader.next()
+            except StopIteration:
+                # No other item, ignore
+                return
             try:
                 # match returns a 5-tuple, the third one being the module name
                 module_name = Use_Stmt.match(line.strline)[2]

--- a/source/fab/steps/analyse.py
+++ b/source/fab/steps/analyse.py
@@ -57,8 +57,6 @@ DEFAULT_SOURCE_GETTER = CollectionConcat([
     ArtefactSet.C_BUILD_FILES,
     # todo: this is lfric stuff so might be better placed elsewhere
     SuffixFilter('psyclone_output', '.f90'),
-    'preprocessed_psyclone',  # todo: this is no longer a collection, remove
-    'configurator_output',
 ])
 
 

--- a/source/fab/steps/analyse.py
+++ b/source/fab/steps/analyse.py
@@ -41,7 +41,7 @@ from pathlib import Path
 from typing import Dict, List, Iterable, Set, Optional, Union
 
 from fab import FabException
-from fab.artefacts import ArtefactsGetter, ArtefactSet, CollectionConcat, SuffixFilter
+from fab.artefacts import ArtefactsGetter, ArtefactSet, CollectionConcat
 from fab.dep_tree import extract_sub_tree, validate_dependencies, AnalysedDependent
 from fab.mo import add_mo_commented_file_deps
 from fab.parse import AnalysedFile, EmptySourceFile
@@ -55,8 +55,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_SOURCE_GETTER = CollectionConcat([
     ArtefactSet.FORTRAN_BUILD_FILES,
     ArtefactSet.C_BUILD_FILES,
-    # todo: this is lfric stuff so might be better placed elsewhere
-    SuffixFilter('psyclone_output', '.f90'),
 ])
 
 

--- a/source/fab/steps/archive_objects.py
+++ b/source/fab/steps/archive_objects.py
@@ -111,7 +111,6 @@ def archive_objects(config: BuildConfig,
     if not output_fpath and list(target_objects.keys()) == [None]:
         raise ValueError("You must specify an output path when building a library.")
 
-    output_archives = config.artefact_store.setdefault(output_collection, {})
     for root, objects in target_objects.items():
 
         if root:
@@ -130,4 +129,5 @@ def archive_objects(config: BuildConfig,
         except RuntimeError as err:
             raise RuntimeError(f"error creating object archive:\n{err}") from err
 
-        output_archives[root] = [output_fpath]
+        config.artefact_store.update_dict(output_collection, root,
+                                          output_fpath)

--- a/source/fab/steps/c_pragma_injector.py
+++ b/source/fab/steps/c_pragma_injector.py
@@ -44,7 +44,7 @@ def c_pragma_injector(config, source: Optional[ArtefactsGetter] = None, output_n
 
     files = source_getter(config.artefact_store)
     results = run_mp(config, items=files, func=_process_artefact)
-    config.artefact_store[output_name] = list(results)
+    config.artefact_store[output_name] = set(results)
     config.artefact_store.replace(ArtefactSet.C_BUILD_FILES,
                                   remove_files=files,
                                   add_files=results)

--- a/source/fab/steps/c_pragma_injector.py
+++ b/source/fab/steps/c_pragma_injector.py
@@ -15,7 +15,7 @@ from fab import FabException
 from fab.artefacts import ArtefactSet, ArtefactsGetter, SuffixFilter
 from fab.steps import run_mp, step
 
-DEFAULT_SOURCE_GETTER = SuffixFilter(ArtefactSet.ALL_SOURCE, '.c')
+DEFAULT_SOURCE_GETTER = SuffixFilter(ArtefactSet.C_BUILD_FILES, '.c')
 
 
 # todo: test
@@ -45,6 +45,9 @@ def c_pragma_injector(config, source: Optional[ArtefactsGetter] = None, output_n
     files = source_getter(config.artefact_store)
     results = run_mp(config, items=files, func=_process_artefact)
     config.artefact_store[output_name] = list(results)
+    config.artefact_store.replace(ArtefactSet.C_BUILD_FILES,
+                                  remove_files=files,
+                                  add_files=results)
 
 
 def _process_artefact(fpath: Path):

--- a/source/fab/steps/find_source_files.py
+++ b/source/fab/steps/find_source_files.py
@@ -139,3 +139,13 @@ def find_source_files(config, source_root=None,
         raise RuntimeError("no source files found after filtering")
 
     config.artefact_store[output_collection] = filtered_fpaths
+
+    # Now split the files into the various main groups:
+    # Fortran, C, and PSyclone
+    config.artefact_store.copy_artefacts(output_collection,
+                                         ArtefactSet.FORTRAN_BUILD_FILES,
+                                         suffixes=[".f90", ".F90"])
+
+    config.artefact_store.copy_artefacts(output_collection,
+                                         ArtefactSet.C_BUILD_FILES,
+                                         suffixes=[".c", ".F90"])

--- a/source/fab/steps/find_source_files.py
+++ b/source/fab/steps/find_source_files.py
@@ -148,4 +148,8 @@ def find_source_files(config, source_root=None,
 
     config.artefact_store.copy_artefacts(output_collection,
                                          ArtefactSet.C_BUILD_FILES,
-                                         suffixes=[".c", ".F90"])
+                                         suffixes=[".c"])
+
+    config.artefact_store.copy_artefacts(output_collection,
+                                         ArtefactSet.X90_BUILD_FILES,
+                                         suffixes=[".x90", ".X90"])

--- a/source/fab/steps/find_source_files.py
+++ b/source/fab/steps/find_source_files.py
@@ -119,7 +119,7 @@ def find_source_files(config, source_root=None,
     source_root = source_root or config.source_root
 
     # file filtering
-    filtered_fpaths = []
+    filtered_fpaths = set()
     # todo: we shouldn't need to ignore the prebuild folder here, it's not underneath the source root.
     for fpath in file_walk(source_root, ignore_folders=[config.prebuild_folder]):
 
@@ -131,7 +131,7 @@ def find_source_files(config, source_root=None,
                 wanted = res
 
         if wanted:
-            filtered_fpaths.append(fpath)
+            filtered_fpaths.add(fpath)
         else:
             logger.debug(f"excluding {fpath}")
 

--- a/source/fab/steps/find_source_files.py
+++ b/source/fab/steps/find_source_files.py
@@ -138,7 +138,7 @@ def find_source_files(config, source_root=None,
     if not filtered_fpaths:
         raise RuntimeError("no source files found after filtering")
 
-    config.artefact_store[output_collection] = filtered_fpaths
+    config.artefact_store.add(output_collection, filtered_fpaths)
 
     # Now split the files into the various main groups:
     # Fortran, C, and PSyclone

--- a/source/fab/steps/preprocess.py
+++ b/source/fab/steps/preprocess.py
@@ -11,7 +11,7 @@ import logging
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Collection, List, Optional, Tuple
+from typing import Collection, List, Optional, Tuple, Union
 
 from fab.artefacts import (ArtefactSet, ArtefactsGetter, SuffixFilter,
                            CollectionGetter)
@@ -36,7 +36,9 @@ class MpCommonArgs():
 
 
 def pre_processor(config: BuildConfig, preprocessor: Preprocessor,
-                  files: Collection[Path], output_collection, output_suffix,
+                  files: Collection[Path],
+                  output_collection: Union[str, ArtefactSet],
+                  output_suffix,
                   common_flags: Optional[List[str]] = None,
                   path_flags: Optional[List] = None,
                   name="preprocess"):
@@ -87,7 +89,7 @@ def pre_processor(config: BuildConfig, preprocessor: Preprocessor,
     check_for_errors(results, caller_label=name)
 
     log_or_dot_finish(logger)
-    config.artefact_store[output_collection] = set(by_type(results, Path))
+    config.artefact_store.add(output_collection, set(by_type(results, Path)))
 
 
 def process_artefact(arg: Tuple[Path, MpCommonArgs]):

--- a/source/fab/steps/preprocess.py
+++ b/source/fab/steps/preprocess.py
@@ -140,7 +140,7 @@ def preprocess_fortran(config: BuildConfig, source: Optional[ArtefactsGetter] = 
     The preprocessor is taken from the `FPP` environment, or falls back to `fpp -P`.
 
     If source is not provided, it defaults to
-    `SuffixFilter(ArtefactStore.ALL_SOURCE, '.F90')`.
+    `SuffixFilter(ArtefactStore.FORTRAN_BUILD_FILES, '.F90')`.
 
     """
     if source:
@@ -216,7 +216,8 @@ class DefaultCPreprocessorSource(ArtefactsGetter):
 
 # todo: rename preprocess_c
 @step
-def preprocess_c(config: BuildConfig, source=None, **kwargs):
+def preprocess_c(config: BuildConfig,
+                 source: Optional[ArtefactsGetter] = None, **kwargs):
     """
     Wrapper to pre_processor for C files.
 

--- a/source/fab/steps/preprocess.py
+++ b/source/fab/steps/preprocess.py
@@ -168,8 +168,8 @@ def preprocess_fortran(config: BuildConfig, source: Optional[ArtefactsGetter] = 
     )
 
     # Add all pre-processed files to the set of files to compile
-    all_preprocessed_files = config.artefact_store[ArtefactSet.PREPROCESSED_FORTRAN]
-    config.artefact_store.add_fortran_build_files(all_preprocessed_files)
+    config.artefact_store.copy_artefacts(ArtefactSet.PREPROCESSED_FORTRAN,
+                                         ArtefactSet.FORTRAN_BUILD_FILES)
 
     # todo: parallel copy?
     # copy little f90s from source to output folder
@@ -181,7 +181,7 @@ def preprocess_fortran(config: BuildConfig, source: Optional[ArtefactsGetter] = 
                 output_path.parent.mkdir(parents=True)
             log_or_dot(logger, f'copying {f90}')
             shutil.copyfile(str(f90), str(output_path))
-            config.artefact_store.add_fortran_build_files(output_path)
+            config.artefact_store.add(ArtefactSet.FORTRAN_BUILD_FILES, output_path)
 
 
 class DefaultCPreprocessorSource(ArtefactsGetter):
@@ -221,5 +221,5 @@ def preprocess_c(config: BuildConfig, source=None, **kwargs):
         **kwargs,
     )
 
-    all_preprocessed_files = config.artefact_store[ArtefactSet.PREPROCESSED_C]
-    config.artefact_store.add_c_build_files(all_preprocessed_files)
+    config.artefact_store.copy_artefacts(ArtefactSet.PREPROCESSED_C,
+                                         ArtefactSet.C_BUILD_FILES)

--- a/source/fab/steps/preprocess.py
+++ b/source/fab/steps/preprocess.py
@@ -181,7 +181,8 @@ def preprocess_fortran(config: BuildConfig, source: Optional[ArtefactsGetter] = 
     # todo: parallel copy?
     # copy little f90s from source to output folder
     logger.info(f'Fortran preprocessor copying {len(f90s)} files to build_output')
-    f90_in_build = []
+    new_files = []
+    remove_files = []
     for f90 in f90s:
         output_path = input_to_output_fpath(config, input_path=f90)
         if output_path != f90:
@@ -189,10 +190,13 @@ def preprocess_fortran(config: BuildConfig, source: Optional[ArtefactsGetter] = 
                 output_path.parent.mkdir(parents=True)
             log_or_dot(logger, f'copying {f90}')
             shutil.copyfile(str(f90), str(output_path))
-            f90_in_build.append(output_path)
+            # Only remove and add a file when it is actually copied.
+            remove_files.append(f90)
+            new_files.append(output_path)
+
     config.artefact_store.replace(ArtefactSet.FORTRAN_BUILD_FILES,
-                                  remove_files=f90s,
-                                  add_files=f90_in_build)
+                                  remove_files=remove_files,
+                                  add_files=new_files)
 
 
 class DefaultCPreprocessorSource(ArtefactsGetter):

--- a/source/fab/steps/preprocess.py
+++ b/source/fab/steps/preprocess.py
@@ -177,10 +177,6 @@ def preprocess_fortran(config: BuildConfig, source: Optional[ArtefactsGetter] = 
                                   remove_files=F90s,
                                   add_files=config.artefact_store[ArtefactSet.PREPROCESSED_FORTRAN])
 
-    # Add all pre-processed files to the set of files to compile
-    config.artefact_store.copy_artefacts(ArtefactSet.PREPROCESSED_FORTRAN,
-                                         ArtefactSet.FORTRAN_BUILD_FILES)
-
     # todo: parallel copy?
     # copy little f90s from source to output folder
     logger.info(f'Fortran preprocessor copying {len(f90s)} files to build_output')
@@ -243,8 +239,6 @@ def preprocess_c(config: BuildConfig,
         **kwargs,
     )
 
-    config.artefact_store.copy_artefacts(ArtefactSet.PREPROCESSED_C,
-                                         ArtefactSet.C_BUILD_FILES)
     config.artefact_store.replace(ArtefactSet.C_BUILD_FILES,
                                   remove_files=source_files,
                                   add_files=config.artefact_store[ArtefactSet.PREPROCESSED_C])

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -146,11 +146,11 @@ def psyclone(config, kernel_roots: Optional[List[Path]] = None,
     check_for_errors(outputs, caller_label='psyclone')
 
     # flatten the list of lists we got back from run_mp
-    output_files: List[Path] = list(chain(*by_type(outputs, List)))
+    output_files: Set[Path] = set(chain(*by_type(outputs, List)))
     prebuild_files: List[Path] = list(chain(*by_type(prebuilds, List)))
 
     # record the output files in the artefact store for further processing
-    config.artefact_store['psyclone_output'] = output_files
+    config.artefact_store.add(ArtefactSet.FORTRAN_BUILD_FILES, output_files)
     outputs_str = "\n".join(map(str, output_files))
     logger.debug(f'psyclone outputs:\n{outputs_str}\n')
 

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -19,8 +19,7 @@ from typing import Dict, List, Optional, Set, Tuple, Union, Callable
 
 from fab.build_config import BuildConfig
 
-from fab.artefacts import (ArtefactSet, ArtefactsGetter, CollectionConcat,
-                           SuffixFilter)
+from fab.artefacts import (ArtefactSet, ArtefactsGetter, SuffixFilter)
 from fab.parse.fortran import FortranAnalyser, AnalysedFortran
 from fab.parse.x90 import X90Analyser, AnalysedX90
 from fab.steps import run_mp, check_for_errors, step
@@ -77,9 +76,8 @@ class MpCommonArgs:
     override_files: List[str]  # filenames (not paths) of hand crafted overrides
 
 
-DEFAULT_SOURCE_GETTER = CollectionConcat([
-    SuffixFilter(ArtefactSet.X90_BUILD_FILES, '.x90'),  # any already preprocessed x90 we pulled in
-])
+# any already preprocessed x90 we pulled in
+DEFAULT_SOURCE_GETTER = SuffixFilter(ArtefactSet.X90_BUILD_FILES, '.x90')
 
 
 @step

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -39,17 +39,22 @@ def preprocess_x90(config, common_flags: Optional[List[str]] = None):
 
     # get the tool from FPP
     fpp = config.tool_box[Categories.FORTRAN_PREPROCESSOR]
-    source_files = SuffixFilter(ArtefactSet.ALL_SOURCE, '.X90')(config.artefact_store)
+    source_files = SuffixFilter(ArtefactSet.X90_BUILD_FILES, '.X90')(config.artefact_store)
 
+    # Add the pre-processed now .x90 files into X90_BUILD_FILES
     pre_processor(
         config,
         preprocessor=fpp,
         files=source_files,
-        output_collection='preprocessed_x90',
+        output_collection=ArtefactSet.X90_BUILD_FILES,
         output_suffix='.x90',
         name='preprocess x90',
         common_flags=common_flags,
     )
+    # Then remove the .X90 files:
+    config.artefact_store.replace(ArtefactSet.X90_BUILD_FILES,
+                                  remove_files=source_files,
+                                  add_files=[])
 
 
 @dataclass
@@ -73,8 +78,7 @@ class MpCommonArgs:
 
 
 DEFAULT_SOURCE_GETTER = CollectionConcat([
-    'preprocessed_x90',  # any X90 we've preprocessed this run
-    SuffixFilter(ArtefactSet.ALL_SOURCE, '.x90'),  # any already preprocessed x90 we pulled in
+    SuffixFilter(ArtefactSet.X90_BUILD_FILES, '.x90'),  # any already preprocessed x90 we pulled in
 ])
 
 

--- a/source/fab/tools/tool.py
+++ b/source/fab/tools/tool.py
@@ -118,8 +118,9 @@ class Tool:
         Run the binary as a subprocess.
 
         :param additional_parameters:
-            List of strings to be sent to :func:`subprocess.run` as the
-            command.
+            List of strings or paths to be sent to :func:`subprocess.run`
+            as additional parameters for the command. Any path will be
+            converted to a normal string.
         :param env:
             Optional env for the command. By default it will use the current
             session's environment.

--- a/tests/unit_tests/steps/test_archive_objects.py
+++ b/tests/unit_tests/steps/test_archive_objects.py
@@ -28,9 +28,10 @@ class TestArchiveObjects():
         targets = ['prog1', 'prog2']
 
         config = BuildConfig('proj', ToolBox())
-        config._artefact_store = {
-            ArtefactSet.OBJECT_FILES: {target: [f'{target}.o', 'util.o']
-                                       for target in targets}}
+        for target in targets:
+            config.artefact_store.update_dict(
+                ArtefactSet.OBJECT_FILES, target,
+                set([f'{target}.o', 'util.o']))
 
         mock_result = mock.Mock(returncode=0, return_value=123)
         with mock.patch('fab.tools.tool.subprocess.run',
@@ -50,7 +51,7 @@ class TestArchiveObjects():
 
         # ensure the correct artefacts were created
         assert config.artefact_store[ArtefactSet.OBJECT_ARCHIVES] == {
-            target: [str(config.build_output / f'{target}.a')] for target in targets}
+            target: set([str(config.build_output / f'{target}.a')]) for target in targets}
 
     def test_for_library(self):
         '''As used when building an object archive or archiving before linking
@@ -58,7 +59,8 @@ class TestArchiveObjects():
         '''
 
         config = BuildConfig('proj', ToolBox())
-        config._artefact_store = {ArtefactSet.OBJECT_FILES: {None: ['util1.o', 'util2.o']}}
+        config.artefact_store.update_dict(
+            ArtefactSet.OBJECT_FILES, None, {'util1.o', 'util2.o'})
 
         mock_result = mock.Mock(returncode=0, return_value=123)
         with mock.patch('fab.tools.tool.subprocess.run',
@@ -73,4 +75,4 @@ class TestArchiveObjects():
 
         # ensure the correct artefacts were created
         assert config.artefact_store[ArtefactSet.OBJECT_ARCHIVES] == {
-            None: [str(config.build_output / 'mylib.a')]}
+            None: set([str(config.build_output / 'mylib.a')])}

--- a/tests/unit_tests/test_artefacts.py
+++ b/tests/unit_tests/test_artefacts.py
@@ -18,7 +18,8 @@ def test_artefact_store():
     assert isinstance(artefact_store, dict)
     assert ArtefactSet.CURRENT_PREBUILDS in artefact_store
     for artefact in ArtefactSet:
-        if artefact == ArtefactSet.OBJECT_FILES:
+        if artefact in [ArtefactSet.OBJECT_FILES,
+                        ArtefactSet.OBJECT_ARCHIVES]:
             assert isinstance(artefact_store[artefact], dict)
         else:
             assert isinstance(artefact_store[artefact], set)

--- a/tests/unit_tests/test_artefacts.py
+++ b/tests/unit_tests/test_artefacts.py
@@ -11,7 +11,7 @@ from fab.artefacts import (ArtefactSet, ArtefactStore, ArtefactsGetter,
                            FilterBuildTrees, SuffixFilter)
 
 
-def test_artefact_store():
+def test_artefact_store() -> None:
     '''Tests the ArtefactStore class.'''
     artefact_store = ArtefactStore()
     assert len(artefact_store) == len(ArtefactSet)
@@ -25,7 +25,7 @@ def test_artefact_store():
             assert isinstance(artefact_store[artefact], set)
 
 
-def test_artefact_store_copy():
+def test_artefact_store_copy() -> None:
     '''Tests the add and copy operations.'''
     artefact_store = ArtefactStore()
     # We need paths for suffix filtering, so create some
@@ -63,28 +63,32 @@ def test_artefact_store_copy():
     assert artefact_store[ArtefactSet.C_BUILD_FILES] == set([a, c])
 
 
-def test_artefact_store_update_dict():
+def test_artefact_store_update_dict() -> None:
     '''Tests the update_dict function.'''
     artefact_store = ArtefactStore()
-    artefact_store.update_dict(ArtefactSet.OBJECT_FILES, "a", ["AA"])
-    assert artefact_store[ArtefactSet.OBJECT_FILES] == {"a": {"AA"}}
-    artefact_store.update_dict(ArtefactSet.OBJECT_FILES, "b", set(["BB"]))
-    assert (artefact_store[ArtefactSet.OBJECT_FILES] == {"a": {"AA"},
-                                                         "b": {"BB"}})
+    artefact_store.update_dict(ArtefactSet.OBJECT_FILES, "a", [Path("AA")])
+    assert artefact_store[ArtefactSet.OBJECT_FILES] == {"a": {Path("AA")}}
+    artefact_store.update_dict(ArtefactSet.OBJECT_FILES,
+                               "b", set([Path("BB")]))
+    assert (artefact_store[ArtefactSet.OBJECT_FILES] == {"a": {Path("AA")},
+                                                         "b": {Path("BB")}})
 
 
-def test_artefact_store_replace():
+def test_artefact_store_replace() -> None:
     '''Tests the replace function.'''
     artefact_store = ArtefactStore()
-    artefact_store.add(ArtefactSet.ALL_SOURCE, ["a", "b", "c"])
-    artefact_store.replace(ArtefactSet.ALL_SOURCE, remove_files=["a", "b"],
-                           add_files=["B"])
-    assert artefact_store[ArtefactSet.ALL_SOURCE] == set(["B", "c"])
+    artefact_store.add(ArtefactSet.ALL_SOURCE, [Path("a"), Path("b"),
+                                                Path("c")])
+    artefact_store.replace(ArtefactSet.ALL_SOURCE,
+                           remove_files=[Path("a"), Path("b")],
+                           add_files=[Path("B")])
+    assert artefact_store[ArtefactSet.ALL_SOURCE] == set([Path("B"),
+                                                          Path("c")])
 
     # Test the behaviour for dictionaries
     with pytest.raises(RuntimeError) as err:
-        artefact_store.replace(ArtefactSet.OBJECT_FILES, remove_files=["a"],
-                               add_files=["c"])
+        artefact_store.replace(ArtefactSet.OBJECT_FILES,
+                               remove_files=[Path("a")], add_files=["c"])
     assert ("Replacing artefacts in dictionary 'ArtefactSet.OBJECT_FILES' "
             "is not supported" in str(err.value))
 
@@ -128,7 +132,7 @@ class TestFilterBuildTrees():
     '''Tests for FilterBuildTrees.'''
 
     @pytest.fixture
-    def artefact_store(self):
+    def artefact_store(self) -> ArtefactStore:
         '''A fixture that returns an ArtefactStore with
         some elements.'''
         artefact_store = ArtefactStore()
@@ -142,7 +146,7 @@ class TestFilterBuildTrees():
                                        }
         return artefact_store
 
-    def test_single_suffix(self, artefact_store):
+    def test_single_suffix(self, artefact_store) -> None:
         '''Ensure the artefact getter passes through the trees properly to
         the filter func.'''
 
@@ -159,7 +163,7 @@ class TestFilterBuildTrees():
                  suffixes=['.foo']),
         ])
 
-    def test_multiple_suffixes(self, artefact_store):
+    def test_multiple_suffixes(self, artefact_store) -> None:
         '''Test it works with multiple suffixes provided.'''
         filter_build_trees = FilterBuildTrees(['.foo', '.bar'])
         with mock.patch('fab.artefacts.filter_source_tree') as mock_filter:
@@ -174,7 +178,7 @@ class TestFilterBuildTrees():
         ])
 
 
-def test_collection_getter():
+def test_collection_getter() -> None:
     '''Test CollectionGetter.'''
     artefact_store = ArtefactStore()
     artefact_store.add(ArtefactSet.ALL_SOURCE, ["a", "b", "c"])

--- a/tests/unit_tests/test_util.py
+++ b/tests/unit_tests/test_util.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 import pytest
 
-from fab.artefacts import CollectionConcat, SuffixFilter
+from fab.artefacts import SuffixFilter
 from fab.util import input_to_output_fpath, suffix_filter, file_walk
 
 
@@ -18,30 +18,14 @@ def fpaths():
     ]
 
 
-class Test_suffix_filter(object):
+class Test_suffix_filter():
 
     def test_vanilla(self, fpaths):
         result = suffix_filter(fpaths=fpaths, suffixes=['.F90', '.f90'])
         assert result == [Path('foo.F90'), Path('foo.f90')]
 
 
-class TestCollectionConcat(object):
-
-    def test_vanilla(self):
-        getter = CollectionConcat(collections=[
-            'fooz',
-            SuffixFilter('barz', '.c')
-        ])
-
-        result = getter(artefact_store={
-            'fooz': ['foo1', 'foo2'],
-            'barz': [Path('bar.a'), Path('bar.b'), Path('bar.c')],
-        })
-
-        assert result == ['foo1', 'foo2', Path('bar.c')]
-
-
-class TestSuffixFilter(object):
+class TestSuffixFilter():
 
     def test_constructor_suffix_scalar(self):
         getter = SuffixFilter('barz', '.c')
@@ -54,7 +38,7 @@ class TestSuffixFilter(object):
         assert result == [Path('bar.b'), Path('bar.c')]
 
 
-class Test_file_walk(object):
+class Test_file_walk():
 
     @pytest.fixture
     def files(self, tmp_path):


### PR DESCRIPTION
This needs to go in after PR #28. It now uses the new enums consistently (i.e. if files are pre-processed, the .F90 files are removed and replaced with the pre-processes .f90 files), so at any stage the C/FORTRAN_BUILD_FILES contains all source files a step needs to look at.

I also updated the run_configs, esp. lfric_common now does NOT create files in `source` anymore, these files are now created in `build/configuration` (and similarly automatically added to the F90_BUILD_FILES)