### PR TITLE
Make Fab more useable for other codes

### DIFF
--- a/run_configs/lfric/atm.py
+++ b/run_configs/lfric/atm.py
@@ -262,6 +262,7 @@ if __name__ == '__main__':
             kernel_roots=[state.build_output / 'lfric' / 'kernel'],
             transformation_script=get_transformation_script,
             cli_args=[],
+            api="dynamo0.3",
         )
 
         # todo: do we need this one in here?

--- a/run_configs/lfric/gungho.py
+++ b/run_configs/lfric/gungho.py
@@ -87,6 +87,7 @@ if __name__ == '__main__':
             kernel_roots=[state.build_output],
             transformation_script=get_transformation_script,
             cli_args=[],
+            api="dynamo0.3",
         )
 
         fparser_workaround_stop_concatenation(state)

--- a/run_configs/lfric/mesh_tools.py
+++ b/run_configs/lfric/mesh_tools.py
@@ -57,6 +57,7 @@ if __name__ == '__main__':
             kernel_roots=[state.build_output],
             cli_args=['--config', Path(__file__).parent / 'psyclone.cfg'],
             overrides_folder=state.source_root / 'mesh_tools_overrides',
+            api="dynamo0.3",
         )
 
         fparser_workaround_stop_concatenation(state)

--- a/source/fab/steps/analyse.py
+++ b/source/fab/steps/analyse.py
@@ -239,7 +239,7 @@ def _parse_files(config, files: List[Path], fortran_analyser, c_analyser) -> Set
 
     """
     # fortran
-    fortran_files = set(filter(lambda f: f.suffix == '.f90', files))
+    fortran_files = set(filter(lambda f: f.suffix in ['.f90', '.f'], files))
     with TimerLogger(f"analysing {len(fortran_files)} preprocessed fortran files"):
         fortran_results = run_mp(config, items=fortran_files, func=fortran_analyser.run)
     fortran_analyses, fortran_artefacts = zip(*fortran_results) if fortran_results else (tuple(), tuple())

--- a/source/fab/steps/compile_fortran.py
+++ b/source/fab/steps/compile_fortran.py
@@ -28,7 +28,7 @@ from fab.util import (CompiledFile, log_or_dot_finish, log_or_dot, Timer,
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_SOURCE_GETTER = FilterBuildTrees(suffix='.f90')
+DEFAULT_SOURCE_GETTER = FilterBuildTrees(suffix=['.f', '.f90'])
 
 
 @dataclass

--- a/source/fab/steps/find_source_files.py
+++ b/source/fab/steps/find_source_files.py
@@ -144,7 +144,7 @@ def find_source_files(config, source_root=None,
     # Fortran, C, and PSyclone
     config.artefact_store.copy_artefacts(output_collection,
                                          ArtefactSet.FORTRAN_BUILD_FILES,
-                                         suffixes=[".f90", ".F90"])
+                                         suffixes=[".f", ".F", ".f90", ".F90"])
 
     config.artefact_store.copy_artefacts(output_collection,
                                          ArtefactSet.C_BUILD_FILES,

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -389,6 +389,9 @@ def _gen_prebuild_hash(x90_file: Path, mp_payload: MpCommonArgs):
 
         # command-line arguments
         string_checksum(str(mp_payload.cli_args)),
+
+        # the API
+        string_checksum(mp_payload.api),
     ])
 
     return prebuild_hash

--- a/source/fab/steps/psyclone.py
+++ b/source/fab/steps/psyclone.py
@@ -391,7 +391,7 @@ def _gen_prebuild_hash(x90_file: Path, mp_payload: MpCommonArgs):
         string_checksum(str(mp_payload.cli_args)),
 
         # the API
-        string_checksum(mp_payload.api),
+        string_checksum(str(mp_payload.api)),
     ])
 
     return prebuild_hash

--- a/source/fab/tools/psyclone.py
+++ b/source/fab/tools/psyclone.py
@@ -23,8 +23,9 @@ class Psyclone(Tool):
     '''This is the base class for `PSyclone`.
     '''
 
-    def __init__(self):
+    def __init__(self, api: Optional[str] = None):
         super().__init__("psyclone", "psyclone", Categories.PSYCLONE)
+        self._api = api
 
     def check_available(self) -> bool:
         '''
@@ -37,7 +38,7 @@ class Psyclone(Tool):
             return False
         return True
 
-    def process(self, api: str,
+    def process(self,
                 config: "BuildConfig",
                 x90_file: Path,
                 psy_file: Path,
@@ -45,7 +46,8 @@ class Psyclone(Tool):
                 transformation_script: Optional[Callable[[Path, "BuildConfig"],
                                                          Path]] = None,
                 additional_parameters: Optional[List[str]] = None,
-                kernel_roots: Optional[List[str]] = None
+                kernel_roots: Optional[List[str]] = None,
+                api: Optional[str] = None,
                 ):
         # pylint: disable=too-many-arguments
         '''Run PSyclone with the specified parameters.
@@ -60,8 +62,18 @@ class Psyclone(Tool):
         :param kernel_roots: optional directories with kernels.
         '''
 
-        parameters: List[Union[str, Path]] = [
-            "-api", api, "-l", "all", "-opsy", psy_file, "-oalg", alg_file]
+        parameters: List[Union[str, Path]] = []
+        # If an api is defined in this call (or in the constructor) add it
+        # as parameter. No API is required if PSyclone works as
+        # transformation tool only, so calling PSyclone without api is
+        # actually valid.
+        if api:
+            parameters.extend(["-api", api])
+        elif self._api:
+            parameters.extend(["-api", self._api])
+
+        parameters.extend(["-l", "all", "-opsy", psy_file, "-oalg", alg_file])
+
         if transformation_script:
             transformation_script_return_path = \
                 transformation_script(x90_file, config)

--- a/tests/system_tests/psyclone/test_psyclone_system_test.py
+++ b/tests/system_tests/psyclone/test_psyclone_system_test.py
@@ -95,7 +95,7 @@ class TestX90Analyser():
         assert analysed_x90 == self.expected_analysis_result
 
 
-class Test_analysis_for_x90s_and_kernels(object):
+class Test_analysis_for_x90s_and_kernels():
 
     def test_analyse(self, tmp_path):
         with BuildConfig('proj', fab_workspace=tmp_path,
@@ -145,7 +145,7 @@ class TestPsyclone():
             config.build_output / 'kernel',
             # this second folder is just to test the multiple folders code, which was bugged. There's no kernels there.
             Path(__file__).parent / 'skeleton/algorithm',
-        ])
+        ], api="dynamo0.3")
 
     def test_run(self, config):
         # if these files exist after the run then we know:
@@ -191,7 +191,7 @@ class TestPsyclone():
         mock_run.assert_not_called()
 
 
-class TestTransformationScript(object):
+class TestTransformationScript():
     """
     Check whether transformation script is called with x90 file once
     and whether transformation script is passed to psyclone after '-s'.

--- a/tests/unit_tests/steps/test_psyclone_unit_test.py
+++ b/tests/unit_tests/steps/test_psyclone_unit_test.py
@@ -38,8 +38,7 @@ class Test_gen_prebuild_hash(object):
         # the script is just hashed later, so any one will do - use this file!
         mock_transformation_script = mock.Mock(return_value=__file__)
 
-        expect_hash = 223133492 + file_checksum(__file__).file_hash  # add the transformation_script_hash
-
+        expect_hash = 3962584109 + file_checksum(__file__).file_hash  # add the transformation_script_hash
         mp_payload = MpCommonArgs(
             analysed_x90=analysed_x90,
             all_kernel_hashes=all_kernel_hashes,

--- a/tests/unit_tests/steps/test_psyclone_unit_test.py
+++ b/tests/unit_tests/steps/test_psyclone_unit_test.py
@@ -47,7 +47,7 @@ class Test_gen_prebuild_hash(object):
             config=None,  # type: ignore[arg-type]
             kernel_roots=[],
             transformation_script=mock_transformation_script,
-            api="dynamo0p3",
+            api="dynamo0.3",
             overrides_folder=None,
             override_files=None,  # type: ignore[arg-type]
         )

--- a/tests/unit_tests/steps/test_psyclone_unit_test.py
+++ b/tests/unit_tests/steps/test_psyclone_unit_test.py
@@ -47,6 +47,7 @@ class Test_gen_prebuild_hash(object):
             config=None,  # type: ignore[arg-type]
             kernel_roots=[],
             transformation_script=mock_transformation_script,
+            api="dynamo0p3",
             overrides_folder=None,
             override_files=None,  # type: ignore[arg-type]
         )

--- a/tests/unit_tests/tools/test_psyclone.py
+++ b/tests/unit_tests/tools/test_psyclone.py
@@ -19,6 +19,14 @@ def test_psyclone_constructor():
     assert psyclone.name == "psyclone"
     assert psyclone.exec_name == "psyclone"
     assert psyclone.flags == []
+    assert psyclone._api is None
+
+    psyclone = Psyclone(api="gocean")
+    assert psyclone.category == Categories.PSYCLONE
+    assert psyclone.name == "psyclone"
+    assert psyclone.exec_name == "psyclone"
+    assert psyclone.flags == []
+    assert psyclone._api == "gocean"
 
 
 def test_psyclone_check_available():
@@ -58,6 +66,58 @@ def test_psyclone_process():
                          additional_parameters=["-c", "psyclone.cfg"])
     tool_run.assert_called_with(
         ['psyclone', '-api', 'dynamo0.3', '-l', 'all', '-opsy', 'psy_file',
+         '-oalg', 'alg_file', '-s', 'script_called', '-c',
+         'psyclone.cfg', '-d', 'root1', '-d', 'root2', 'x90_file'],
+        capture_output=True, env=None, cwd=None, check=False)
+
+    # Don't specify an API:
+    with mock.patch('fab.tools.tool.subprocess.run',
+                    return_value=mock_result) as tool_run:
+        psyclone.process(config=config,
+                         x90_file="x90_file",
+                         psy_file="psy_file",
+                         alg_file="alg_file",
+                         transformation_script=transformation_function,
+                         kernel_roots=["root1", "root2"],
+                         additional_parameters=["-c", "psyclone.cfg"])
+    tool_run.assert_called_with(
+        ['psyclone', '-l', 'all', '-opsy', 'psy_file', '-oalg', 'alg_file',
+         '-s', 'script_called', '-c',
+         'psyclone.cfg', '-d', 'root1', '-d', 'root2', 'x90_file'],
+        capture_output=True, env=None, cwd=None, check=False)
+
+    # Don't specify an API, but define an API on the PSyclone tool:
+    psyclone = Psyclone(api="gocean")
+    with mock.patch('fab.tools.tool.subprocess.run',
+                    return_value=mock_result) as tool_run:
+        psyclone.process(config=config,
+                         x90_file="x90_file",
+                         psy_file="psy_file",
+                         alg_file="alg_file",
+                         transformation_script=transformation_function,
+                         kernel_roots=["root1", "root2"],
+                         additional_parameters=["-c", "psyclone.cfg"])
+    tool_run.assert_called_with(
+        ['psyclone', '-api', 'gocean', '-l', 'all', '-opsy', 'psy_file',
+         '-oalg', 'alg_file', '-s', 'script_called', '-c',
+         'psyclone.cfg', '-d', 'root1', '-d', 'root2', 'x90_file'],
+        capture_output=True, env=None, cwd=None, check=False)
+
+    # Have both a default and a command line option - the latter
+    # must take precedence:
+    psyclone = Psyclone(api="gocean")
+    with mock.patch('fab.tools.tool.subprocess.run',
+                    return_value=mock_result) as tool_run:
+        psyclone.process(config=config,
+                         x90_file="x90_file",
+                         psy_file="psy_file",
+                         alg_file="alg_file",
+                         api="lfric",
+                         transformation_script=transformation_function,
+                         kernel_roots=["root1", "root2"],
+                         additional_parameters=["-c", "psyclone.cfg"])
+    tool_run.assert_called_with(
+        ['psyclone', '-api', 'lfric', '-l', 'all', '-opsy', 'psy_file',
          '-oalg', 'alg_file', '-s', 'script_called', '-c',
          'psyclone.cfg', '-d', 'root1', '-d', 'root2', 'x90_file'],
         capture_output=True, env=None, cwd=None, check=False)

--- a/tests/unit_tests/tools/test_psyclone.py
+++ b/tests/unit_tests/tools/test_psyclone.py
@@ -21,12 +21,12 @@ def test_psyclone_constructor():
     assert psyclone.flags == []
     assert psyclone._api is None
 
-    psyclone = Psyclone(api="gocean")
+    psyclone = Psyclone(api="gocean1.0")
     assert psyclone.category == Category.PSYCLONE
     assert psyclone.name == "psyclone"
     assert psyclone.exec_name == "psyclone"
     assert psyclone.flags == []
-    assert psyclone._api == "gocean"
+    assert psyclone._api == "gocean1.0"
 
 
 def test_psyclone_check_available():
@@ -87,7 +87,7 @@ def test_psyclone_process():
         capture_output=True, env=None, cwd=None, check=False)
 
     # Don't specify an API, but define an API on the PSyclone tool:
-    psyclone = Psyclone(api="gocean")
+    psyclone = Psyclone(api="gocean1.0")
     with mock.patch('fab.tools.tool.subprocess.run',
                     return_value=mock_result) as tool_run:
         psyclone.process(config=config,
@@ -98,26 +98,26 @@ def test_psyclone_process():
                          kernel_roots=["root1", "root2"],
                          additional_parameters=["-c", "psyclone.cfg"])
     tool_run.assert_called_with(
-        ['psyclone', '-api', 'gocean', '-l', 'all', '-opsy', 'psy_file',
+        ['psyclone', '-api', 'gocean1.0', '-l', 'all', '-opsy', 'psy_file',
          '-oalg', 'alg_file', '-s', 'script_called', '-c',
          'psyclone.cfg', '-d', 'root1', '-d', 'root2', 'x90_file'],
         capture_output=True, env=None, cwd=None, check=False)
 
     # Have both a default and a command line option - the latter
     # must take precedence:
-    psyclone = Psyclone(api="gocean")
+    psyclone = Psyclone(api="gocean1.0")
     with mock.patch('fab.tools.tool.subprocess.run',
                     return_value=mock_result) as tool_run:
         psyclone.process(config=config,
                          x90_file="x90_file",
                          psy_file="psy_file",
                          alg_file="alg_file",
-                         api="lfric",
+                         api="dynamo0.3",
                          transformation_script=transformation_function,
                          kernel_roots=["root1", "root2"],
                          additional_parameters=["-c", "psyclone.cfg"])
     tool_run.assert_called_with(
-        ['psyclone', '-api', 'lfric', '-l', 'all', '-opsy', 'psy_file',
+        ['psyclone', '-api', 'dynamo0.3', '-l', 'all', '-opsy', 'psy_file',
          '-oalg', 'alg_file', '-s', 'script_called', '-c',
          'psyclone.cfg', '-d', 'root1', '-d', 'root2', 'x90_file'],
         capture_output=True, env=None, cwd=None, check=False)

--- a/tests/unit_tests/tools/test_psyclone.py
+++ b/tests/unit_tests/tools/test_psyclone.py
@@ -22,7 +22,7 @@ def test_psyclone_constructor():
     assert psyclone._api is None
 
     psyclone = Psyclone(api="gocean")
-    assert psyclone.category == Categories.PSYCLONE
+    assert psyclone.category == Category.PSYCLONE
     assert psyclone.name == "psyclone"
     assert psyclone.exec_name == "psyclone"
     assert psyclone.flags == []


### PR DESCRIPTION
Besides making the PSyclone API configurable, it also allows to use no-API, which is the future way in PSyclone to use the former 'NEMO' API, i.e. transformation of existing Fortran codes.

Additionally, it adds support for .f/.F files.